### PR TITLE
move tools which is only used for dev to dev.dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,14 +14,14 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "3.8.16"
+
+[tool.poetry.group.dev.dependencies]
+pyproject-flake8 = "^6.0.0.post1"
 black = "^22.12.0"
 isort = "^5.11.4"
 pytest = "^7.2.1"
 pytest-cov = "^4.0.0"
 mypy = "^0.991"
-
-[tool.poetry.group.dev.dependencies]
-pyproject-flake8 = "^6.0.0.post1"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
pyproject.tomlの修正を行いました。
以下のツールをdev.dependenciesのグループに移動しました。
* black
* isort
* pytest
* pytest-cov
* mypy
poetry checkで確認済みです。