### PR TITLE
fix the test of ckan command

### DIFF
--- a/ckanext/feedback/tests/command/test_feedback.py
+++ b/ckanext/feedback/tests/command/test_feedback.py
@@ -28,6 +28,9 @@ class TestFeedbackCommand:
         model.repo.metadata.clear()
         model.repo.init_db()
 
+    def teardown_class(cls):
+        model.repo.metadata.reflect()
+
     def setup_method(self, method):
         self.runner = CliRunner()
 


### PR DESCRIPTION
テストの2回目を実行した際にいくつかのテストが失敗してしまうバグの改善を行いました。

### 原因

結論としては`ckanext/feedback/tests/command/test_feedback.py`で行っていた`model.repo.metadata.clear()`が原因でした。

fixtureの`clean_db`の処理は
最初の実行 → テーブルを全てドロップし、初期化を行う
2回目以降の実行 → `model.repo.metadata`のテーブル情報を用いてテーブル内の要素をDELETEする
といったものでした。

`model.repo.metadata.clear()`で`clean_db`で利用する`metadata`のテーブル情報が削除されたことで
以降のテストでテーブル内の要素がDELETEされずに残ってしまっておりました。

そのため、2回目以降のテストでダミー要素を追加しようとした際、
前回の要素のせいで、ユニーク制約等に引っかかりテストが失敗しておりました。

### 修正点

`ckanext/feedback/tests/command/test_feedback.py`のテストの最後に以下の処理を追加しました。

```python
def teardown_class(cls):
        model.repo.metadata.reflect()
```

これにより`metadata`にテスト終了後のDB内に存在するテーブル情報(CKAN本体の初期状態)を反映することで
以降のテストで`clean_db`を行った際にそれぞれのテーブル内の要素が削除されるようにいたしました。

よろしくお願いします。