### PR TITLE
modify the setup.sh to be able to constract container

### DIFF
--- a/development/setup.sh
+++ b/development/setup.sh
@@ -3,5 +3,7 @@
 git submodule update --init --recursive
 # Copy docker/.env.template as .env
 cp external/ckan/contrib/docker/.env.template external/ckan/contrib/docker/.env
+# overwrite the version of zopw.interface from 4.3.2 to 5.0.0
+sed -i -e 's/zope.interface==4.3.2/zope.interface==5.0.0/' external/ckan/requirements.txt
 # Build and compose docker containers
 docker compose -f external/ckan/contrib/docker/docker-compose.yml -f docker-compose.yml up --build -d


### PR DESCRIPTION
エラー文について検索してみたところ、議論がされていることを発見いたしました。

[Cannot import name "Feature" from "setuptools" in version 46.0.0 #2017](https://github.com/pypa/setuptools/issues/2017)

その中で以下のことが述べられています。
1. `Features`は非推奨であり、2020年3月に削除された
2. `setuptools==45`とすることで回避できる可能性がある
3. `zope.interface`のバージョンを`5.0.0`以上にすることで回避できる
4. 公式からの正式な文書は出ていない模様

この中で有効であった3を導入したPRを作成いたしました。
具体的には`setup.sh`の中で`zope.interface`のバージョンの書き換えを行うように修正をしております。