### PR TITLE
bulk delete時に total_rating が Noneになるバグ対応

### DIFF
--- a/ckanext/feedback/services/management/comments.py
+++ b/ckanext/feedback/services/management/comments.py
@@ -75,11 +75,15 @@ def refresh_resources_comments(resource_comment_summaries):
             )
             .first()
         )
+        if row.total_rating is None:
+            rating = 0
+        else:
+            rating = row.total_rating / row.total_comment
         mappings.append(
             {
                 'id': resource_comment_summary.id,
                 'comment': row.total_comment,
-                'rating': row.total_rating / row.total_comment,
+                'rating': rating,
                 'updated': datetime.now(),
             }
         )

--- a/ckanext/feedback/tests/services/management/test_comments.py
+++ b/ckanext/feedback/tests/services/management/test_comments.py
@@ -319,6 +319,26 @@ class TestComments:
 
         assert mock_mappings.call_args[0] == (ResourceCommentSummary, expected_mapping)
 
+        comments.delete_resource_comments([resource_comment[0].id, another_resource_comment[0].id])
+        comments.refresh_resources_comments(resource_comment_summaries)
+        session.commit()
+        expected_mapping = [
+            {
+                'id': resource_comment_summary.id,
+                'comment': 0,
+                'rating': 0,
+                'updated': datetime.now(),
+            },
+            {
+                'id': another_resource_comment_summary.id,
+                'comment': 0,
+                'rating': 0,
+                'updated': datetime.now(),
+            },
+        ]
+
+        assert mock_mappings.call_args[0] == (ResourceCommentSummary, expected_mapping)
+
     @pytest.mark.freeze_time(datetime(2000, 1, 2, 3, 4))
     @patch('ckanext.feedback.services.management.comments.session.bulk_update_mappings')
     def test_approve_utilization_comments(self, mock_mappings):


### PR DESCRIPTION
リソースコメントが一件のみ登録/承認されている状態で、Bulk Delete時に以下のエラーが発生したので修正対応

原因：bulk delete後にコメントが一件も無くなることでrefreshの際に `total_rating`が`None`になる
対応：`total_ragting`が`None`の際は再集計結果の`rating`を`0`にする

```
TypeError
TypeError: unsupported operand type(s) for /: 'NoneType' and 'int'
Traceback (most recent call last)
* 		File "/usr/lib/ckan/venv/lib/python3.8/site-packages/flask/app.py", line 2449, in wsgi_app response = self.handle_exception(e)  
* 		File "/usr/lib/ckan/venv/lib/python3.8/site-packages/flask/app.py", line 1866, in handle_exception reraise(exc_type, exc_value, tb)  
* 		File "/usr/lib/ckan/venv/lib/python3.8/site-packages/flask/_compat.py", line 39, in reraise raise value  
* 		File "/usr/lib/ckan/venv/lib/python3.8/site-packages/flask/app.py", line 2446, in wsgi_app response = self.full_dispatch_request()  
* 		File "/usr/lib/ckan/venv/lib/python3.8/site-packages/flask/app.py", line 1951, in full_dispatch_request rv = self.handle_user_exception(e)  
* 		File "/usr/lib/ckan/venv/lib/python3.8/site-packages/flask/app.py", line 1821, in handle_user_exception return handler(e)  
* 		File "/usr/lib/ckan/venv/lib/python3.8/site-packages/ckanext/feedback/views/error_handler.py", line 29, in handle_exception raise e  
* 		File "/usr/lib/ckan/venv/lib/python3.8/site-packages/flask/app.py", line 1949, in full_dispatch_request rv = self.dispatch_request()  
* 		File "/usr/lib/ckan/venv/lib/python3.8/site-packages/flask_debugtoolbar/__init__.py", line 125, in dispatch_request return view_func(**req.view_args)  
* 		File "/usr/lib/ckan/venv/lib/python3.8/site-packages/ckanext/feedback/services/common/check.py", line 9, in wrapper return func(*args, **kwargs)  
* 		File "/usr/lib/ckan/venv/lib/python3.8/site-packages/ckanext/feedback/controllers/management.py", line 100, in delete_bulk_resource_comments comments_service.refresh_resources_comments(resource_comment_summaries)  
* 		File "/usr/lib/ckan/venv/lib/python3.8/site-packages/ckanext/feedback/services/management/comments.py", line 89, in refresh_resources_comments 'rating': row.total_rating / row.total_comment,  
TypeError: unsupported operand type(s) for /: 'NoneType' and 'int'
```