### PR TITLE
package_item.html : CKAN2.10系への対応修正

### DIFF
--- a/ckanext/feedback/templates/snippets/package_item.html
+++ b/ckanext/feedback/templates/snippets/package_item.html
@@ -3,13 +3,15 @@
 {% block resources_inner %}
   {% asset 'feedback/feedback-package-item-css' %}
   {% asset 'feedback/feedback-tooltip-css' %}
+  {% for resource in h.dict_list_reduce(package.resources, 'format') %}
+    <li>
+      <a href="{{ h.url_for(package.type ~ '.read', id=package.name) }}" class="badge badge-default" data-format="{{ resource.lower() }}">{{ resource }}</a>
+    </li>
+  {% endfor %}
   <li>
-    {% for resource in h.dict_list_reduce(package.resources, 'format') %}
-      <a href="{{ h.url_for(package.type ~ '.read', id=package.name) }}" class="label label-default" data-format="{{ resource.lower() }}">{{ resource }}</a>
-    {% endfor %}
     {% if h.is_enabled_downloads_org(package.owner_org) %}
       <div class = "bubble">
-        <i class="fa fa-arrow-circle-o-down"></i>
+        <i class="fas fa-arrow-circle-down"></i>
         {{ h.get_package_downloads(package.id) }}
         <div class="description">{{ _('Downloads') }}</div>
       </div>
@@ -18,7 +20,7 @@
   <li>
     {% if h.is_enabled_utilizations_org(package.owner_org) %}
       <div class="utilization-data bubble">
-        <i class="fa fa-pencil-square-o"></i>
+        <i class="fas fa-pencil-alt"></i>
         <a href="{{ h.url_for('utilization.search', id=package.id, disable_keyword=true) }}">{{ h.get_package_utilizations(package.id) }}</a>
         <div class="description">{{ _('Utilizations') }}</div>
       </div>
@@ -27,7 +29,7 @@
   <li>
     {% if h.is_enabled_resources_org(package.owner_org) %}
       <div class="utilization-data bubble">
-        <i class="fa fa-commenting-o"></i>
+        <i class="fas fa-comment-dots"></i>
         {{ h.get_package_comments(package.id) }}
         <div class="description">{{ _('Comments') }}</div>
       </div>
@@ -37,7 +39,7 @@
     {% if h.is_enabled_resources_org(package.owner_org) %}
       {% if h.is_enabled_rating_org(package.owner_org) %}
         <div class="utilization-data bubble">
-          <i class="fa fa-star"></i>
+          <i class="fas fa-star"></i>
           {{ h.get_package_rating(package.id)|round(1) }}
           <div class="description">{{ _('Rating') }}</div>
         </div>


### PR DESCRIPTION
* CKAN 2.10系の`package_item.html`ファイルを使用して、書き直しを行いました。
  * CKAN 2.10系の`package_item.html`をベースに書き換え
  * 各モジュールのアイコンのFont Awesome5 への対応

正常に表示されるか確認済みです。