### PR TITLE
additional_info.html : CKAN2.10系への対応修正

### DIFF
--- a/ckanext/feedback/templates/package/snippets/additional_info.html
+++ b/ckanext/feedback/templates/package/snippets/additional_info.html
@@ -31,12 +31,15 @@
       <td class="dataset-details">{{ h.get_package_issue_resolutions(pkg_dict.id) }}</td>
     </tr>
   {% endif %}
-  
   {% if pkg_dict.url %}
     <tr>
       <th scope="row" class="dataset-label">{{ _('Source') }}</th>
       {% if h.is_url(pkg_dict.url) %}
-        <td class="dataset-details" property="foaf:homepage">{{ h.link_to(pkg_dict.url, pkg_dict.url, rel='foaf:homepage', target='_blank') }}</td>
+        <td class="dataset-details" property="foaf:homepage">
+          <a href="{{ pkg_dict.url }}" rel="foaf:homepage" target="_blank">
+            {{ pkg_dict.url }}
+          </a>
+        </td>
       {% else %}
         <td class="dataset-details" property="foaf:homepage">{{ pkg_dict.url }}</td>
       {% endif %}
@@ -101,5 +104,4 @@
       </tr>
     {% endfor %}
   {% endblock %}
-
 {% endblock %}


### PR DESCRIPTION
* CKAN 2.10系の`additional_info.html`ファイルを使用して、書き直しを行いました。
  * CKAN 2.10系の`additional_info.html`をベースに書き換え

正常に表示されるか確認済みです。