### PR TITLE
コメント管理画面のタイトルが「CKAN」

### DIFF
--- a/ckanext/feedback/templates/management/comments.html
+++ b/ckanext/feedback/templates/management/comments.html
@@ -10,6 +10,7 @@
   <li class="active"><a href="{{ h.url_for('management.comments') }}">{{ _('Management Comments') }}</a></li>
 {% endblock %}
 
+{% block title %}{{ _('Management Comments') }} - {{ super() }}{% endblock %}
 
 {% block primary %}
   <article class="module">

--- a/ckanext/feedback/templates/management/comments.html
+++ b/ckanext/feedback/templates/management/comments.html
@@ -10,7 +10,7 @@
   <li class="active"><a href="{{ h.url_for('management.comments') }}">{{ _('Management Comments') }}</a></li>
 {% endblock %}
 
-{% block title %}{{ _('Management Comments') }} - {{ super() }}{% endblock %}
+{% block title %}{{ _('Management Comments') }} - CKAN{% endblock %}
 
 {% block primary %}
   <article class="module">

--- a/ckanext/feedback/templates/resource/comment.html
+++ b/ckanext/feedback/templates/resource/comment.html
@@ -15,7 +15,7 @@
     <li class="active"><a href="#">{{ _('Comment') }}</a></li>
   {% endblock %}
 
-  {% block title %}{{ _('Comment') }} - {{ pkg_dict.title }} - {{ resource.name }} - CKAN{% endblock %}
+  {% block title %}{{ _('Comment on Resource') }} - {{ pkg_dict.title }} - {{ resource.name }} - CKAN{% endblock %}
 
   {% block primary %}
     <article class="module" role="main">

--- a/ckanext/feedback/templates/resource/comment.html
+++ b/ckanext/feedback/templates/resource/comment.html
@@ -15,6 +15,8 @@
     <li class="active"><a href="#">{{ _('Comment') }}</a></li>
   {% endblock %}
 
+  {% block title %}{{ _('Comment') }} - {{ pkg_dict.title }} - {{ resource.name }} - CKAN{% endblock %}
+
   {% block primary %}
     <article class="module" role="main">
       <div class="module-content">

--- a/ckanext/feedback/templates/utilization/details.html
+++ b/ckanext/feedback/templates/utilization/details.html
@@ -12,6 +12,8 @@
     <li class="active"><a href="{{ h.url_for('utilization.details', utilization_id=utilization_id) }}">{{ _('Details') }}</a></li>
   {% endblock %}
 
+  {% block title %}{{ _('Detail') }} - {{ utilization.title }} - {{ _('Utilization') }} - CKAN{% endblock %}
+
   {% block primary %}
     <article class="module" role="main">
       <div class="module-content">

--- a/ckanext/feedback/templates/utilization/details.html
+++ b/ckanext/feedback/templates/utilization/details.html
@@ -12,7 +12,7 @@
     <li class="active"><a href="{{ h.url_for('utilization.details', utilization_id=utilization_id) }}">{{ _('Details') }}</a></li>
   {% endblock %}
 
-  {% block title %}{{ _('Detail') }} - {{ utilization.title }} - {{ _('Utilization') }} - CKAN{% endblock %}
+  {% block title %}{{ _('Details on Utilization') }} - {{ utilization.title }} - {{ _('Utilization') }} - CKAN{% endblock %}
 
   {% block primary %}
     <article class="module" role="main">

--- a/ckanext/feedback/templates/utilization/details.html
+++ b/ckanext/feedback/templates/utilization/details.html
@@ -12,7 +12,7 @@
     <li class="active"><a href="{{ h.url_for('utilization.details', utilization_id=utilization_id) }}">{{ _('Details') }}</a></li>
   {% endblock %}
 
-  {% block title %}{{ _('Details on Utilization') }} - {{ utilization.title }} - {{ _('Utilization') }} - CKAN{% endblock %}
+  {% block title %}{{ _('Details on Utilization') }} - {{ utilization.title }} - {{ utilization.package_name }} - {{ utilization.resource_name }} - CKAN{% endblock %}
 
   {% block primary %}
     <article class="module" role="main">

--- a/ckanext/feedback/templates/utilization/edit.html
+++ b/ckanext/feedback/templates/utilization/edit.html
@@ -13,7 +13,7 @@
     <li class="active"><a href="">{{ _('Edit') }}</a></li>
   {% endblock %}
 
-  {% block title %}{{ _('Edit') }} - {{ utilization_details.title }} - {{ _('Utilization') }} - CKAN{% endblock %}
+  {% block title %}{{ _('Edit Utilization') }} - {{ utilization_details.title }} - {{ _('Utilization') }} - CKAN{% endblock %}
 
   {% block primary %}
     <article class="module" role="main">

--- a/ckanext/feedback/templates/utilization/edit.html
+++ b/ckanext/feedback/templates/utilization/edit.html
@@ -13,6 +13,8 @@
     <li class="active"><a href="">{{ _('Edit') }}</a></li>
   {% endblock %}
 
+  {% block title %}{{ _('Edit') }} - {{ utilization_details.title }} - {{ _('Utilization') }} - CKAN{% endblock %}
+
   {% block primary %}
     <article class="module" role="main">
       <div class="module-content">

--- a/ckanext/feedback/templates/utilization/edit.html
+++ b/ckanext/feedback/templates/utilization/edit.html
@@ -13,7 +13,7 @@
     <li class="active"><a href="">{{ _('Edit') }}</a></li>
   {% endblock %}
 
-  {% block title %}{{ _('Edit Utilization') }} - {{ utilization_details.title }} - {{ _('Utilization') }} - CKAN{% endblock %}
+  {% block title %}{{ _('Edit Utilization') }} - {{ utilization_details.title }} - {{ resource_details.package_name }} - {{ resource_details.resource_name }} - CKAN{% endblock %}
 
   {% block primary %}
     <article class="module" role="main">

--- a/ckanext/feedback/templates/utilization/new.html
+++ b/ckanext/feedback/templates/utilization/new.html
@@ -15,6 +15,8 @@
     <li class="active"><a href="">{{ _('Create utilization application') }}</a></li>
   {% endblock %}
 
+  {% block title %}{{ _('Create Utilization Application') }} - {{ pkg_dict.title }} - {{ resource.name }} - CKAN{% endblock %}
+
   {%- block primary %}
     <article class="module" role="main">
       <div class="module-content">

--- a/ckanext/feedback/templates/utilization/search.html
+++ b/ckanext/feedback/templates/utilization/search.html
@@ -12,6 +12,8 @@
     <li class="active"><a href="{{ h.url_for('utilization.search') }}">{{ _('Utilization') }}</a></li>
   {% endblock %}
 
+  {% block title %}{{ _('Utilization') }} - CKAN{% endblock %}
+
   {% block primary %}
     <form class="top-centered-content" method="get">
       {% block search_by_keyword %}

--- a/ckanext/feedback/templates/utilization/search.html
+++ b/ckanext/feedback/templates/utilization/search.html
@@ -12,7 +12,7 @@
     <li class="active"><a href="{{ h.url_for('utilization.search') }}">{{ _('Utilization') }}</a></li>
   {% endblock %}
 
-  {% block title %}{{ _('Utilization') }} - CKAN{% endblock %}
+  {% block title %}{{ _('Search for Utilizations') }} - CKAN{% endblock %}
 
   {% block primary %}
     <form class="top-centered-content" method="get">


### PR DESCRIPTION
フィードバック機能が独自に作成したページについて
CKANに準拠した形でタイトルを設定しました。

※ i18n対応はしていません。[issure # 141](https://github.com/c-3lab/ckanext-feedback/issues/141)で対応予定です。