### PR TITLE
組織名が特定可能な場合にテンプレートで取得できるようにする

### DIFF
--- a/ckanext/feedback/controllers/management.py
+++ b/ckanext/feedback/controllers/management.py
@@ -1,4 +1,4 @@
-from ckan.common import _, current_user, request
+from ckan.common import _, current_user, g, request
 from ckan.lib import helpers
 from ckan.plugins import toolkit
 from flask import redirect, url_for
@@ -32,6 +32,11 @@ class ManagementController:
             utilization_comments = utilization_detail_service.get_utilization_comments(
                 owner_orgs=ids
             )
+            g.pkg_dict = {
+                'organization': {
+                    'name': current_user.get_groups(group_type='organization')[0].name,
+                }
+            }
         else:
             resource_comments = resource_comment_service.get_resource_comments()
             utilization_comments = utilization_detail_service.get_utilization_comments()

--- a/ckanext/feedback/controllers/resource.py
+++ b/ckanext/feedback/controllers/resource.py
@@ -1,5 +1,5 @@
 import ckan.model as model
-from ckan.common import _, current_user, request
+from ckan.common import _, current_user, g, request
 from ckan.lib import helpers
 from ckan.logic import get_action
 from ckan.plugins import toolkit
@@ -36,6 +36,11 @@ class ResourceController:
         cookie = comment_service.get_cookie(resource_id)
         context = {'model': model, 'session': session, 'for_view': True}
         package = get_action('package_show')(context, {'id': resource.package_id})
+        g.pkg_dict = {
+            'organization': {
+                'name': resource.package.get_groups(group_type='organization')[0].name
+            }
+        }
 
         return toolkit.render(
             'resource/comment.html',

--- a/ckanext/feedback/controllers/utilization.py
+++ b/ckanext/feedback/controllers/utilization.py
@@ -1,5 +1,5 @@
 import ckan.model as model
-from ckan.common import _, current_user, request
+from ckan.common import _, current_user, g, request
 from ckan.lib import helpers
 from ckan.logic import get_action
 from ckan.plugins import toolkit
@@ -48,6 +48,24 @@ class UtilizationController:
             id, keyword, approval, admin_owner_orgs, org_name
         )
 
+        # If the organization name can be identified,
+        # set it as a global variable accessible from templates.
+        if id and not org_name:
+            resource = registration_service.get_resource(id)
+            package: model.Package
+            if resource:
+                package = resource.package
+            else:
+                package = model.Package.get(id)
+            if package:
+                org_name = package.get_groups(group_type='organization')[0].name
+        if org_name:
+            g.pkg_dict = {
+                'organization': {
+                    'name': org_name,
+                },
+            }
+
         return toolkit.render(
             'utilization/search.html',
             {
@@ -65,6 +83,11 @@ class UtilizationController:
         resource = registration_service.get_resource(resource_id)
         context = {'model': model, 'session': session, 'for_view': True}
         package = get_action('package_show')(context, {'id': resource.package.id})
+        g.pkg_dict = {
+            'organization': {
+                'name': resource.package.get_groups(group_type='organization')[0].name
+            }
+        }
 
         return toolkit.render(
             'utilization/new.html',
@@ -120,6 +143,13 @@ class UtilizationController:
         comments = detail_service.get_utilization_comments(utilization_id, approval)
         categories = detail_service.get_utilization_comment_categories()
         issue_resolutions = detail_service.get_issue_resolutions(utilization_id)
+        g.pkg_dict = {
+            'organization': {
+                'name': registration_service.get_resource(utilization.resource_id)
+                .package.get_groups(group_type='organization')[0]
+                .name
+            }
+        }
 
         return toolkit.render(
             'utilization/details.html',
@@ -185,6 +215,15 @@ class UtilizationController:
         resource_details = edit_service.get_resource_details(
             utilization_details.resource_id
         )
+        g.pkg_dict = {
+            'organization': {
+                'name': registration_service.get_resource(
+                    utilization_details.resource_id
+                )
+                .package.get_groups(group_type='organization')[0]
+                .name
+            }
+        }
 
         return toolkit.render(
             'utilization/edit.html',

--- a/ckanext/feedback/controllers/utilization.py
+++ b/ckanext/feedback/controllers/utilization.py
@@ -52,7 +52,6 @@ class UtilizationController:
         # set it as a global variable accessible from templates.
         if id and not org_name:
             resource = registration_service.get_resource(id)
-            package: model.Package
             if resource:
                 package = resource.package
             else:


### PR DESCRIPTION
以下のテンプレート内で `{% c.pkg_dict['organization']['name'] %}` にて組織名を取得できるように修正。
- management/comments.html
- resource/comment.html
- utilization/details.html
- utilization/edit.html
- utilization/new.html
- utilization/search.html

※ 組織名取得元DBカラム：ckan.model.group.name