### PR TITLE
downloadモジュールの外部プラグイン連携強化

### DIFF
--- a/ckanext/feedback/controllers/download.py
+++ b/ckanext/feedback/controllers/download.py
@@ -18,7 +18,7 @@ class DownloadController:
 
         handler = feedback_config.download_handler()
         if not handler:
-            log.debug("Use default CKAN callback for resource.download")
+            log.debug('Use default CKAN callback for resource.download')
             handler = resource.download
         return handler(
             package_type=package_type,

--- a/ckanext/feedback/controllers/download.py
+++ b/ckanext/feedback/controllers/download.py
@@ -1,7 +1,12 @@
-from ckan.views.resource import download
+import logging
+
+import ckan.views.resource as resource
 from flask import request
 
+from ckanext.feedback.services.common import config as feedback_config
 from ckanext.feedback.services.download.summary import increment_resource_downloads
+
+log = logging.getLogger(__name__)
 
 
 class DownloadController:
@@ -10,4 +15,14 @@ class DownloadController:
     def extended_download(package_type, id, resource_id, filename=None):
         if request.headers.get('Sec-Fetch-Dest') == 'document':
             increment_resource_downloads(resource_id)
-        return download(package_type, id, resource_id, filename=filename)
+
+        handler = feedback_config.download_handler()
+        if not handler:
+            log.debug("Use default CKAN callback for resource.download")
+            handler = resource.download
+        return handler(
+            package_type=package_type,
+            id=id,
+            resource_id=resource_id,
+            filename=filename,
+        )

--- a/ckanext/feedback/services/common/config.py
+++ b/ckanext/feedback/services/common/config.py
@@ -8,7 +8,7 @@ from ckanext.feedback.models.session import session
 
 log = logging.getLogger(__name__)
 
-CONFIG_HANDLER_PATH = "ckan.feedback.download_handler"
+CONFIG_HANDLER_PATH = 'ckan.feedback.download_handler'
 
 
 def get_organization(org_id=None):
@@ -21,6 +21,6 @@ def download_handler():
         handler = import_string(handler_path, silent=True)
     else:
         handler = None
-        log.warning(("Missing {} config option.").format(CONFIG_HANDLER_PATH))
+        log.warning(f'Missing {CONFIG_HANDLER_PATH} config option.')
 
     return handler

--- a/ckanext/feedback/services/common/config.py
+++ b/ckanext/feedback/services/common/config.py
@@ -1,7 +1,26 @@
+import logging
+
 from ckan.model.group import Group
+from ckan.plugins import toolkit
+from werkzeug.utils import import_string
 
 from ckanext.feedback.models.session import session
+
+log = logging.getLogger(__name__)
+
+CONFIG_HANDLER_PATH = "ckan.feedback.download_handler"
 
 
 def get_organization(org_id=None):
     return session.query(Group.name.label('name')).filter(Group.id == org_id).first()
+
+
+def download_handler():
+    handler_path = toolkit.config.get(CONFIG_HANDLER_PATH)
+    if handler_path:
+        handler = import_string(handler_path, silent=True)
+    else:
+        handler = None
+        log.warning(("Missing {} config option.").format(CONFIG_HANDLER_PATH))
+
+    return handler

--- a/ckanext/feedback/views/download.py
+++ b/ckanext/feedback/views/download.py
@@ -1,7 +1,14 @@
+import logging
+
+import ckan.views.resource as resource
+from ckan.common import config
 from flask import Blueprint
 
 from ckanext.feedback.controllers.download import DownloadController
+from ckanext.feedback.services.common import config as feedback_config
 from ckanext.feedback.views.error_handler import add_error_handler
+
+log = logging.getLogger(__name__)
 
 blueprint = Blueprint(
     'download',
@@ -22,3 +29,19 @@ blueprint.add_url_rule(
 @add_error_handler
 def get_download_blueprint():
     return blueprint
+
+
+def download(package_type, id, resource_id, filename=None):
+    if config.get('ckan.feedback.downloads.enable', True):
+        handler = DownloadController.extended_download
+    else:
+        handler = feedback_config.download_handler()
+        if not handler:
+            log.debug("Use default CKAN callback for resource.download")
+            handler = resource.download
+    return handler(
+        package_type=package_type,
+        id=id,
+        resource_id=resource_id,
+        filename=filename,
+    )

--- a/ckanext/feedback/views/download.py
+++ b/ckanext/feedback/views/download.py
@@ -37,7 +37,7 @@ def download(package_type, id, resource_id, filename=None):
     else:
         handler = feedback_config.download_handler()
         if not handler:
-            log.debug("Use default CKAN callback for resource.download")
+            log.debug('Use default CKAN callback for resource.download')
             handler = resource.download
     return handler(
         package_type=package_type,

--- a/ckanext/feedback/views/download.py
+++ b/ckanext/feedback/views/download.py
@@ -31,6 +31,7 @@ def get_download_blueprint():
     return blueprint
 
 
+# Handler to Use When Called from External Extensions
 def download(package_type, id, resource_id, filename=None):
     if config.get('ckan.feedback.downloads.enable', True):
         handler = DownloadController.extended_download

--- a/docs/ja/switch_function.md
+++ b/docs/ja/switch_function.md
@@ -43,7 +43,7 @@
 
 ## downloadモジュールを外部プラグインと連携する場合
 
-リソースがダウンロードされると、downloadモジュールはダウンロード数のカウント追加処理を行った後、デフォルトのダウンロードコールバックを呼び出します。CKAN>=2.10 を使用していて、一部のプラグインが`resource.download`ルートを再定義する場合(ckanext-googleanalytics など)、`ckan.views.resource:download`を使用する代わりにどの関数を呼び出す必要があるかを設定変数`ckan.feedback.download_handler`にて指定できます。</br>
+リソースがダウンロードされると、downloadモジュールはダウンロード数のカウント追加処理を行った後、デフォルトのダウンロードコールバックを呼び出します。CKAN>=2.10 を使用していて、一部のプラグインが`resource.download`ルートを再定義する場合(ckanext-googleanalytics など)、`ckan.views.resource:download`を使用する代わりにどの関数を呼び出す必要があるかを`ckan.ini`内の設定変数`ckan.feedback.download_handler`にて指定できます。</br>
 例として、ckanext-googleanalytics を指定する場合は、以下の設定を使用できます。
 
 ```bash

--- a/docs/ja/switch_function.md
+++ b/docs/ja/switch_function.md
@@ -43,16 +43,20 @@
 
 ## downloadモジュールを外部プラグインと連携する場合
 
-リソースがダウンロードされると、downloadモジュールはダウンロード数のカウント追加処理を行った後、デフォルトのダウンロードコールバックを呼び出します。CKAN>=2.10 を使用していて、一部のプラグインが`resource.download`ルートを再定義する場合(ckanext-googleanalytics など)、`ckan.views.resource:download`を使用する代わりにどの関数を呼び出す必要があるかを`ckan.ini`内の設定変数`ckan.feedback.download_handler`にて指定できます。</br>
-例として、ckanext-googleanalytics を指定する場合は、以下の設定を使用できます。
+リソースがダウンロードされると、downloadモジュールはダウンロード数のカウント処理を行った後、デフォルトのダウンロードコールバックである`ckan.views.resource:download`を呼び出します。しかし、`ckan.ini`内の設定変数`ckan.feedback.download_handler`により、`ckan.views.resource:download`を他のExtension（例：[googleanalytics](https://github.com/ckan/ckanext-googleanalytics)）のダウンロードハンドラに置き換えることも可能です。
+
+例：ckanext-googleanalytics の場合
 
 ```bash
 ckan.feedback.download_handler = ckanext.googleanalytics.views:download
 ```
 
-上記とは逆に、外部プラグインからckanext-feedbackのdownloadモジュールをコールバックとして指定する場合、`ckanext.feedback.views.download:download`が使用できます。</br>
-例として、ckanext-googleanalyticsのdownloadハンドラとしてckanext-feedbackのdownloadモジュールを指定する場合は、以下の設定を使用できます。
+また、逆に外部ハンドラを設定できる他のExtensionのコールバックとしてckanext-feedbackのdownloadモジュールを指定したい場合は、`ckanext.feedback.views.download:download`を使用できます。
+
+例：ckanext-googleanalytics の場合
 
 ```bash
 googleanalytics.download_handler = ckanext.feedback.views.download:download
 ```
+
+これらの連携方法は、複数のextensionを使用する際に`/download`などのパスが競合してしまう場合に役立ちます。

--- a/docs/ja/switch_function.md
+++ b/docs/ja/switch_function.md
@@ -43,7 +43,9 @@
 
 ## downloadモジュールを外部プラグインと連携する場合
 
-リソースがダウンロードされると、downloadモジュールはダウンロード数のカウント処理を行った後、デフォルトのダウンロードコールバックである`ckan.views.resource:download`を呼び出します。しかし、`ckan.ini`内の設定変数`ckan.feedback.download_handler`により、`ckan.views.resource:download`を他のExtension（例：[googleanalytics](https://github.com/ckan/ckanext-googleanalytics)）のダウンロードハンドラに置き換えることも可能です。
+リソースがダウンロードされると、downloadモジュールはダウンロード数のカウント処理を行った後、デフォルトのダウンロードコールバックである`ckan.views.resource:download`を呼び出します。</br>
+しかし、そのコールバックを他Extensionの関数（例：[googleanalytics](https://github.com/ckan/ckanext-googleanalytics) のdonwload関数）に変更したい場合があります。</br>
+その場合ckan.ini内の設定変数ckan.feedback.download_handlerへ対象の関数を指定することで置き換えることも可能です。
 
 例：ckanext-googleanalytics の場合
 

--- a/docs/ja/switch_function.md
+++ b/docs/ja/switch_function.md
@@ -40,3 +40,19 @@
 
 3. テーブル作成(まだの方のみ)
     * [feedbackコマンド](./feedback_command.md)の```-modules```オプションを参考に**オンにするモジュール**のテーブル作成を行なってください
+
+## downloadモジュールを外部プラグインと連携する場合
+
+リソースがダウンロードされると、downloadモジュールはダウンロード数のカウント追加処理を行った後、デフォルトのダウンロードコールバックを呼び出します。CKAN>=2.10 を使用していて、一部のプラグインが`resource.download`ルートを再定義する場合(ckanext-googleanalytics など)、`ckan.views.resource:download`を使用する代わりにどの関数を呼び出す必要があるかを設定変数`ckan.feedback.download_handler`にて指定できます。</br>
+例として、ckanext-googleanalytics を指定する場合は、以下の設定を使用できます。
+
+```bash
+ckan.feedback.download_handler = ckanext.googleanalytics.views:download
+```
+
+上記とは逆に、外部プラグインからckanext-feedbackのdownloadモジュールをコールバックとして指定する場合、`ckanext.feedback.views.download:download`が使用できます。</br>
+例として、ckanext-googleanalyticsのdownloadハンドラとしてckanext-feedbackのdownloadモジュールを指定する場合は、以下の設定を使用できます。
+
+```bash
+googleanalytics.download_handler = ckanext.feedback.views.download:download
+```


### PR DESCRIPTION
- 設定ファイルを通じて、外部プラグインのdownloadハンドラを指定可能にしました。指定がない場合はデフォルトの`ckan.views.resource.download()`が使用されます。
- 他の外部プラグインからckanext-feedbackのdownloadモジュールを呼び出すためのハンドラを追加しました。