### PR TITLE
commit時にリンター、フォーマッターを実行できるようにした

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+-   repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+    -   id: isort
+
+-   repo: https://github.com/psf/black
+    rev: stable
+    hooks:
+    -   id: black
+
+-   repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+    -   id: flake8
+        entry: pflake8
+        additional_dependencies: [pyproject-flake8]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,10 +35,6 @@ sqlalchemy = "^1.3.5"
 psycopg2 = "2.9.3"
 
 [tool.poetry.group.dev.dependencies]
-pyproject-flake8 = "^6.0.0.post1"
-flake8-quotes = "^3.3.2"
-black = "^23.1.0"
-isort = "^5.11.4"
 pytest = "^7.2.1"
 pytest-cov = "^4.0.0"
 mypy = "^0.991"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ alembic = "1.0.0"
 requests = "2.25.1"
 passlib = "1.6.5"
 python-magic = "0.4.15"
-pyyaml = "5.4.1"
+pyyaml = "6.0.1"
 webassets = "0.12.1"
 pyjwt = "1.7.1"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ python-magic = "0.4.15"
 pyyaml = "6.0.1"
 webassets = "0.12.1"
 pyjwt = "1.7.1"
+pre-commit = "3.5.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
- poetory をインストールしてある環境の本リポジトリの .git があるディレクトリで、 `poetry run pre-commit install` を実行すると、以後、git commit 時に、staging されているファイルに対して  isort , black, pflake8 が実行され、それらによる修正が発生すると、commit されなくなります。
- 手動で isort , black, pflake8 を行いたい場合、`poetry run pre-commit` で可能です。
-  `poetry run pre-commit install` が必要な点について、ドキュメントした方が良いかもしれないです。その場合、どのドキュメントに書くべきでしょうか？