### PR TITLE
Use organization_name as a filter in keyword search if identified

### DIFF
--- a/ckanext/feedback/templates/utilization/search.html
+++ b/ckanext/feedback/templates/utilization/search.html
@@ -20,6 +20,9 @@
         <br>
         {% if not disable_keyword %}
           <h4>{{ _('Keyword Search') }}</h4>
+          {% if c.pkg_dict %}
+            <input type="hidden" name="organization"  value="{{ c.pkg_dict['organization']['name'] }}">
+          {% endif %}
           <div class="input-group search-input-group">
             <input id="field-giant-search" type="text" class="form-control input-lg" name="keyword" placeholder="{{ _('Keyword Search...') }}" aria-label="{{ _('Search utilization data') }}" autocomplete="off" value="{{ keyword }}"/>
             <span class="input-group-btn">


### PR DESCRIPTION
組織名が特定されている状態でのキーワード検索は、その組織内の検索とする修正。

組織名が特定されている条件
- getリクエストのパラメータ`id`に `ckan.model.package.id` 又は `ckan.model.resource.id` の値を指定してアクセスした。
又は
- getリクエストのパラメータ`organization`に `ckan.model.group.name` の値が指定してアクセスした。

※ 参考
https://github.com/c-3lab/ckanext-feedback/pull/163