### PR TITLE
Utilization にURLの項目を追加

### DIFF
--- a/ckanext/feedback/controllers/utilization.py
+++ b/ckanext/feedback/controllers/utilization.py
@@ -103,12 +103,13 @@ class UtilizationController:
         package_name = request.form.get('package_name', '')
         resource_id = request.form.get('resource_id', '')
         title = request.form.get('title', '')
+        url = request.form.get('url', '')
         description = request.form.get('description', '')
         if not (resource_id and title and description):
             toolkit.abort(400)
 
         return_to_resource = toolkit.asbool(request.form.get('return_to_resource'))
-        registration_service.create_utilization(resource_id, title, description)
+        registration_service.create_utilization(resource_id, title, url, description)
         summary_service.create_utilization_summary(resource_id)
         session.commit()
 
@@ -238,11 +239,12 @@ class UtilizationController:
     def update(utilization_id):
         UtilizationController._check_organization_admin_role(utilization_id)
         title = request.form.get('title', '')
+        url = request.form.get('url', '')
         description = request.form.get('description', '')
         if not (title and description):
             toolkit.abort(400)
 
-        edit_service.update_utilization(utilization_id, title, description)
+        edit_service.update_utilization(utilization_id, title, url, description)
         session.commit()
 
         helpers.flash_success(

--- a/ckanext/feedback/controllers/utilization.py
+++ b/ckanext/feedback/controllers/utilization.py
@@ -145,9 +145,11 @@ class UtilizationController:
         issue_resolutions = detail_service.get_issue_resolutions(utilization_id)
         g.pkg_dict = {
             'organization': {
-                'name': registration_service.get_resource(utilization.resource_id)
-                .package.get_groups(group_type='organization')[0]
-                .name
+                'name': (
+                    registration_service.get_resource(utilization.resource_id)
+                    .package.get_groups(group_type='organization')[0]
+                    .name
+                )
             }
         }
 
@@ -217,11 +219,11 @@ class UtilizationController:
         )
         g.pkg_dict = {
             'organization': {
-                'name': registration_service.get_resource(
-                    utilization_details.resource_id
+                'name': (
+                    registration_service.get_resource(utilization_details.resource_id)
+                    .package.get_groups(group_type='organization')[0]
+                    .name
                 )
-                .package.get_groups(group_type='organization')[0]
-                .name
             }
         }
 

--- a/ckanext/feedback/models/utilization.py
+++ b/ckanext/feedback/models/utilization.py
@@ -27,6 +27,7 @@ class Utilization(Base):
         nullable=False,
     )
     title = Column(Text)
+    url = Column(Text)
     description = Column(Text)
     comment = Column(Integer, default=0)
     created = Column(TIMESTAMP, default=datetime.now)

--- a/ckanext/feedback/services/utilization/details.py
+++ b/ckanext/feedback/services/utilization/details.py
@@ -17,6 +17,7 @@ def get_utilization(utilization_id):
     return (
         session.query(
             Utilization.title,
+            Utilization.url,
             Utilization.description,
             Utilization.comment,
             Utilization.approval,

--- a/ckanext/feedback/services/utilization/edit.py
+++ b/ckanext/feedback/services/utilization/edit.py
@@ -25,9 +25,10 @@ def get_resource_details(resource_id):
 
 
 # Update utilization
-def update_utilization(utilization_id, title, description):
+def update_utilization(utilization_id, title, url, description):
     utilization = session.query(Utilization).get(utilization_id)
     utilization.title = title
+    utilization.url = url
     utilization.description = description
 
 

--- a/ckanext/feedback/services/utilization/registration.py
+++ b/ckanext/feedback/services/utilization/registration.py
@@ -10,10 +10,11 @@ def get_resource(resource_id):
 
 
 # Create new utilization
-def create_utilization(resource_id, title, description):
+def create_utilization(resource_id, title, url, description):
     utilization = Utilization(
         resource_id=resource_id,
         title=title,
+        url=url,
         description=description,
     )
     session.add(utilization)

--- a/ckanext/feedback/templates/utilization/details.html
+++ b/ckanext/feedback/templates/utilization/details.html
@@ -38,6 +38,9 @@
             <h4>{{ _('Resource') }}</h4>
             <a href="{{ h.url_for('dataset.search') }}{{ row.package_name }}/resource/{{ row.resource_id }}">{{ row.resource_name }}</a>
             <hr>
+            <h4>{{ _('URL') }}</h4>
+            <a href="{{ row.url }}" target="_blank">{{ row.url }}</a>
+            <hr>
             <h4>{{ _('Utilization description') }}</h4>
             <p class="multiple-line">{{ row.description }}</p>
             <hr>

--- a/ckanext/feedback/templates/utilization/edit.html
+++ b/ckanext/feedback/templates/utilization/edit.html
@@ -36,6 +36,10 @@
           </div>
           <br>
           <hr>
+          <h4>{{ _('URL (Example : The URL for your Website or Service)') }}</h4>
+          <input type="text" class="form-control" id="url" name="url" value="{{ utilization_details.url }}"/>
+          <br>
+          <hr>
           <h4>{{ _('Description') }}</h4>
           <textarea class="form-control" cols="20" rows="5" id="description" name="description">{{ utilization_details.description }}</textarea>
           <div>

--- a/ckanext/feedback/templates/utilization/edit.html
+++ b/ckanext/feedback/templates/utilization/edit.html
@@ -36,6 +36,7 @@
           </div>
           <br>
           <hr>
+          <small>{{ _('※ option') }}</small>
           <h4>{{ _('URL (Example : The URL for your Website or Service)') }}</h4>
           <input type="text" class="form-control" id="url" name="url" value="{{ utilization_details.url }}"/>
           <br>

--- a/ckanext/feedback/templates/utilization/new.html
+++ b/ckanext/feedback/templates/utilization/new.html
@@ -39,6 +39,7 @@
           </div>
           <br>
           <hr>
+          <small>{{ _('※ option') }}</small>
           <h4>{{ _('URL (Example : The URL for your Website or Service)') }}</h4>
           <input type="text" class="form-control" id="url" name="url"/>
           <br>

--- a/ckanext/feedback/templates/utilization/new.html
+++ b/ckanext/feedback/templates/utilization/new.html
@@ -35,8 +35,12 @@
           <h4>{{ _('Title') }}</h4>
           <input type="text" class="form-control" id="title" name="title"/>
           <div>
-            <p id="title-error" class="alert alert-error" style="display: none;"">{{ _('Please enter a title') }}</p>
+            <p id="title-error" class="alert alert-error" style="display: none;">{{ _('Please enter a title') }}</p>
           </div>
+          <br>
+          <hr>
+          <h4>{{ _('URL (Example : The URL for your Website or Service)') }}</h4>
+          <input type="text" class="form-control" id="url" name="url"/>
           <br>
           <hr>
           <h4>{{ _('Description') }}</h4>


### PR DESCRIPTION
`Utilization` の項目として`url`を追加しました。

* URLが入力されていなくても、利活用方法の登録が可能です。
* 利活用方法詳細画面ではリンクとして表示されます。(クリックすると別タブで開きます。)