### PR TITLE
テストCI カバレッジのアップロードに失敗する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,7 @@ jobs:
         if: always()
         uses: codecov/codecov-action@v3.1.0
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           fail_ci_if_error: true
           working-directory: ./development

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,5 @@ jobs:
         uses: codecov/codecov-action@v3.1.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
+          files: ./development/coverage.xml
           fail_ci_if_error: true
-          working-directory: ./development

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,11 +44,11 @@ jobs:
       - name: db setting
         run: |
           docker exec -i ckan-docker-ckan-dev-1 bash -c "ckan -c /usr/lib/python3.10/site-packages/ckanext/feedback/tests/config/test.ini db init"
-      
+
       - name: Run test
         run: |
           docker exec -i ckan-docker-ckan-dev-1 bash -c "CKAN_SQLALCHEMY_URL= CKAN_DATASTORE_READ_URL= CKAN_DATASTORE_WRITE_URL= pytest --cov-report=xml:/tmp/coverage.xml --ckan-ini=/usr/lib/python3.10/site-packages/ckanext/feedback/tests/config/test.ini --cov=ckanext.feedback --cov-branch --disable-warnings --cov-report=term-missing /usr/lib/python3.10/site-packages/ckanext/feedback/tests"
-      
+
       - name: copy coverage.xml
         if: always()
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,7 @@ jobs:
         working-directory: ./development
 
       - name: Upload coverage to Codecov
+        if: always()
         uses: codecov/codecov-action@v3.1.0
         with:
           files: ./coverage.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,12 +44,15 @@ jobs:
       - name: db setting
         run: |
           docker exec -i ckan-docker-ckan-dev-1 bash -c "ckan -c /usr/lib/python3.10/site-packages/ckanext/feedback/tests/config/test.ini db init"
-
+      
       - name: Run test
         run: |
           docker exec -i ckan-docker-ckan-dev-1 bash -c "CKAN_SQLALCHEMY_URL= CKAN_DATASTORE_READ_URL= CKAN_DATASTORE_WRITE_URL= pytest --cov-report=xml:/tmp/coverage.xml --ckan-ini=/usr/lib/python3.10/site-packages/ckanext/feedback/tests/config/test.ini --cov=ckanext.feedback --cov-branch --disable-warnings --cov-report=term-missing /usr/lib/python3.10/site-packages/ckanext/feedback/tests"
-          docker cp ckan-docker-ckan-dev-1:/tmp/coverage.xml ./coverage.xml
-        working-directory: ./development
+      
+      - name: copy coverage.xml
+        if: always()
+        run: |
+          docker cp ckan-docker-ckan-dev-1:/tmp/coverage.xml ./development/coverage.xml
 
       - name: Upload coverage to Codecov
         if: always()


### PR DESCRIPTION
カバレッジレポートが正常にCodeCovへアップロードされるように修正します。