### PR TITLE
Google reCAPTUREの導入

### DIFF
--- a/ckanext/feedback/assets/js/recaptcha.js
+++ b/ckanext/feedback/assets/js/recaptcha.js
@@ -1,0 +1,19 @@
+var content_form = document.getElementById(feedback_recaptcha_target_form);
+content_form.onsubmit = function(event) {
+  event.preventDefault();
+  grecaptcha.ready(function() {
+    grecaptcha.execute(feedback_recaptcha_publickey, {action: feedback_recaptcha_action}).then(function(token) {
+      var token_input = document.createElement('input');
+      token_input.type = 'hidden';
+      token_input.name = 'g-recaptcha-response';
+      token_input.value = token;
+      content_form.appendChild(token_input);
+      var action_input = document.createElement('input');
+      action_input.type = 'hidden';
+      action_input.name = 'action';
+      action_input.value = feedback_recaptcha_action;
+      content_form.appendChild(action_input);
+      content_form.submit();
+    });
+  });
+}

--- a/ckanext/feedback/assets/js/recaptcha.js
+++ b/ckanext/feedback/assets/js/recaptcha.js
@@ -1,19 +1,19 @@
-var content_form = document.getElementById(feedback_recaptcha_target_form);
-content_form.onsubmit = function(event) {
+const contentForm = document.getElementById(feedbackRecaptchaTargetForm);
+contentForm.onsubmit = function(event) {
   event.preventDefault();
   grecaptcha.ready(function() {
-    grecaptcha.execute(feedback_recaptcha_publickey, {action: feedback_recaptcha_action}).then(function(token) {
-      var token_input = document.createElement('input');
-      token_input.type = 'hidden';
-      token_input.name = 'g-recaptcha-response';
-      token_input.value = token;
-      content_form.appendChild(token_input);
-      var action_input = document.createElement('input');
-      action_input.type = 'hidden';
-      action_input.name = 'action';
-      action_input.value = feedback_recaptcha_action;
-      content_form.appendChild(action_input);
-      content_form.submit();
+    grecaptcha.execute(feedbackRecaptchaPublickey, {action: feedbackRecaptchaAction}).then(function(token) {
+      const tokenInput = document.createElement('input');
+      tokenInput.type = 'hidden';
+      tokenInput.name = 'g-recaptcha-response';
+      tokenInput.value = token;
+      contentForm.appendChild(tokenInput);
+      const actionInput = document.createElement('input');
+      actionInput.type = 'hidden';
+      actionInput.name = 'action';
+      actionInput.value = feedbackRecaptchaAction;
+      contentForm.appendChild(actionInput);
+      contentForm.submit();
     });
   });
 }

--- a/ckanext/feedback/assets/webassets.yml
+++ b/ckanext/feedback/assets/webassets.yml
@@ -37,6 +37,12 @@ feedback-management-comments-js:
   contents:
     - js/management_comments.js
 
+feedback-recaptcha-js:
+  filter: rjsmin
+  output: ckanext-feedback/%(version)s-recaptch.js
+  contents:
+    - js/recaptcha.js
+
 feedback-search-css:
   filter: cssrewrite
   output: feedback/%(version)s-search.css

--- a/ckanext/feedback/controllers/utilization.py
+++ b/ckanext/feedback/controllers/utilization.py
@@ -83,7 +83,7 @@ class UtilizationController:
 
     # utilization/new
     @staticmethod
-    def new(resource_id=None):
+    def new(resource_id=None, title='', description=''):
         if not resource_id:
             resource_id = request.args.get('resource_id', '')
         return_to_resource = request.args.get('return_to_resource', False)
@@ -102,6 +102,8 @@ class UtilizationController:
                 'pkg_dict': package,
                 'return_to_resource': return_to_resource,
                 'resource': resource,
+                'title': title,
+                'description': description,
             },
         )
 
@@ -118,7 +120,7 @@ class UtilizationController:
 
         if not is_recaptcha_verified(request):
             helpers.flash_error(_(u'Bad Captcha. Please try again.'), allow_html=True)
-            return UtilizationController.new(resource_id)
+            return UtilizationController.new(resource_id, title, description)
 
         return_to_resource = toolkit.asbool(request.form.get('return_to_resource'))
         utilization = registration_service.create_utilization(

--- a/ckanext/feedback/controllers/utilization.py
+++ b/ckanext/feedback/controllers/utilization.py
@@ -165,7 +165,7 @@ class UtilizationController:
 
     # utilization/<utilization_id>
     @staticmethod
-    def details(utilization_id):
+    def details(utilization_id, category='', content=''):
         approval = True
         utilization = detail_service.get_utilization(utilization_id)
         if not isinstance(current_user, model.User):
@@ -196,6 +196,8 @@ class UtilizationController:
                 'comments': comments,
                 'categories': categories,
                 'issue_resolutions': issue_resolutions,
+                'selected_category': category,
+                'content': content,
             },
         )
 
@@ -218,6 +220,10 @@ class UtilizationController:
         content = request.form.get('content', '')
         if not (category and content):
             toolkit.abort(400)
+
+        if not is_recaptcha_verified(request):
+            helpers.flash_error(_(u'Bad Captcha. Please try again.'), allow_html=True)
+            return UtilizationController.details(utilization_id, category, content)
 
         detail_service.create_utilization_comment(utilization_id, category, content)
         session.commit()

--- a/ckanext/feedback/plugin.py
+++ b/ckanext/feedback/plugin.py
@@ -13,6 +13,7 @@ from ckanext.feedback.services.common import check
 from ckanext.feedback.services.common import config as feedback_config
 from ckanext.feedback.services.download import summary as download_summary_service
 from ckanext.feedback.services.management import comments as management_comments_service
+from ckanext.feedback.services.recaptcha import check as recaptcha_check_service
 from ckanext.feedback.services.resource import comment as comment_service
 from ckanext.feedback.services.resource import summary as resource_summary_service
 from ckanext.feedback.services.utilization import summary as utilization_summary_service
@@ -100,6 +101,20 @@ class FeedbackPlugin(plugins.SingletonPlugin, DefaultTranslation):
                     )
                     config['ckan.feedback.utilizations.enable_orgs'] = (
                         feedback_config.utilizations.enable_orgs
+                    )
+                except AttributeError as e:
+                    toolkit.error_shout(e)
+
+                # the settings related to recaptcha module
+                try:
+                    config['ckan.feedback.recaptcha.enable'] = (
+                        feedback_config.recaptcha.enable
+                    )
+                    config['ckan.feedback.recaptcha.privatekey'] = (
+                        feedback_config.recaptcha.privatekey
+                    )
+                    config['ckan.feedback.recaptcha.publickey'] = (
+                        feedback_config.recaptcha.publickey
                     )
                 except AttributeError as e:
                     toolkit.error_shout(e)
@@ -299,6 +314,12 @@ class FeedbackPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'get_resource_rating': resource_summary_service.get_resource_rating,
             'get_package_rating': resource_summary_service.get_package_rating,
             'get_organization': management_comments_service.get_organization,
+            'is_enabled_feedback_recaptcha': (
+                recaptcha_check_service.is_enabled_recaptcha
+            ),
+            'get_feedback_recaptcha_publickey': (
+                recaptcha_check_service.get_feedback_recaptcha_publickey
+            ),
         }
 
     # IPackageController

--- a/ckanext/feedback/services/recaptcha/check.py
+++ b/ckanext/feedback/services/recaptcha/check.py
@@ -1,0 +1,79 @@
+import logging
+
+import requests
+from ckan.common import config
+from ckan.plugins import toolkit
+from ckan.types import Request
+
+logger = logging.getLogger(__name__)
+
+
+class CaptchaError(ValueError):
+    pass
+
+
+def is_enabled_recaptcha():
+    enable = config.get('ckan.feedback.recaptcha.enable', False)
+    return toolkit.asbool(enable)
+
+
+def get_feedback_recaptcha_publickey() -> str:
+    return config.get('ckan.feedback.recaptcha.publickey')
+
+
+def _check_recaptcha_v3_base(request: Request) -> None:
+    '''Check a user's recaptcha submission is valid, and raise CaptchaError
+    on failure using discreet data'''
+    client_ip_address = request.remote_addr or 'Unknown IP Address'
+    recaptcha_response = request.form.get('g-recaptcha-response', '')
+    if not recaptcha_response:
+        logger.warning("not recaptcha_response")
+        raise CaptchaError()
+
+    recaptcha_private_key = config.get('ckan.feedback.recaptcha.privatekey')
+    if not recaptcha_private_key:
+        logger.warning("not recaptcha_private_key")
+        raise CaptchaError()
+
+    # reCAPTCHA v3
+    recaptcha_server_name = 'https://www.google.com/recaptcha/api/siteverify'
+
+    # recaptcha_response_field will be unicode if there are foreign chars in
+    # the user input. So we need to encode it as utf8 before urlencoding or
+    # we get an exception.
+    params = {
+        'secret': recaptcha_private_key,
+        'remoteip': client_ip_address,
+        'response': recaptcha_response.encode('utf8'),
+    }
+
+    timeout = config.get('ckan.requests.timeout')
+
+    data = requests.get(recaptcha_server_name, params, timeout=timeout).json()
+    score_threshold = float(config.get('ckan.feedback.recaptcha.score_threshold', 0.5))
+
+    try:
+        if not data['success']:
+            logger.warning(f"not success:{data}")
+            raise CaptchaError()
+        if data['score'] < score_threshold:
+            logger.warning(
+                f"Score is below the threshold:{data}:score_threshold={score_threshold}"
+            )
+            raise CaptchaError()
+    except IndexError:
+        # Something weird with recaptcha response
+        logger.error("IndexError")
+        raise CaptchaError()
+
+    logger.info(f"reCAPTCHA verification passed successfully:{data}")
+    return
+
+
+def is_recaptcha_verified(request: Request):
+    if is_enabled_recaptcha():
+        try:
+            _check_recaptcha_v3_base(request)
+        except CaptchaError:
+            return False
+    return True

--- a/ckanext/feedback/services/recaptcha/check.py
+++ b/ckanext/feedback/services/recaptcha/check.py
@@ -67,7 +67,6 @@ def _check_recaptcha_v3_base(request: Request) -> None:
         raise CaptchaError()
 
     logger.info(f"reCAPTCHA verification passed successfully:{data}")
-    return
 
 
 def is_recaptcha_verified(request: Request):

--- a/ckanext/feedback/templates/resource/comment.html
+++ b/ckanext/feedback/templates/resource/comment.html
@@ -182,9 +182,9 @@
     {% if h.is_enabled_feedback_recaptcha %}
       <script src="https://www.google.com/recaptcha/api.js?render={{ h.get_feedback_recaptcha_publickey() }}"></script>
       <script>
-        let feedback_recaptcha_target_form = 'comment_form'
-        let feedback_recaptcha_action = 'resource_comment'
-        let feedback_recaptcha_publickey = '{{ h.get_feedback_recaptcha_publickey() }}'
+        const feedbackRecaptchaTargetForm = 'comment_form'
+        const feedbackRecaptchaAction = 'resource_comment'
+        const feedbackRecaptchaPublickey = '{{ h.get_feedback_recaptcha_publickey() }}'
       </script>
       {% asset 'feedback/feedback-recaptcha-js'%}
     {% endif %}

--- a/ckanext/feedback/templates/resource/comment.html
+++ b/ckanext/feedback/templates/resource/comment.html
@@ -46,16 +46,20 @@
               </div>
             {% endif %}
             <br>
-            <form name="comment_form" action="{{ url_for('resource_comment.create_comment', resource_id=resource.id ) }}" method="post">
+            <form id="comment_form" name="comment_form" action="{{ url_for('resource_comment.create_comment', resource_id=resource.id ) }}" method="post">
               <input type="hidden" id="rating" name="rating" value=""/>
               <select name="category" id="category">
                 {% for category in categories %}
-                  <option value="{{ category.name }}">{{ _(category.value) }}</option>
+                {% if category.name == selected_category %}
+                <option value="{{ category.name }}" selected>{{ _(category.value) }}</option>
+                {% else %}
+                <option value="{{ category.name }}">{{ _(category.value) }}</option>
+                {% endif %}
                 {% endfor %}
               </select>
               <br>
               <br>
-              <textarea class="form-control" cols="20" rows="5" id="comment_content" name="comment_content"></textarea>
+              <textarea class="form-control" cols="20" rows="5" id="comment_content" name="comment_content">{{ content }}</textarea>
               <div>
                 <p id="comment-error" class="alert alert-error" style="display: none;">{{ _('Please enter your comment') }}</p>
               </div>
@@ -175,6 +179,15 @@
   {%- block scripts %}
     {{ super() }}
     {% asset 'feedback/feedback-comment-js' %}
+    {% if h.is_enabled_feedback_recaptcha %}
+      <script src="https://www.google.com/recaptcha/api.js?render={{ h.get_feedback_recaptcha_publickey() }}"></script>
+      <script>
+        let feedback_recaptcha_target_form = 'comment_form'
+        let feedback_recaptcha_action = 'resource_comment'
+        let feedback_recaptcha_publickey = '{{ h.get_feedback_recaptcha_publickey() }}'
+      </script>
+      {% asset 'feedback/feedback-recaptcha-js'%}
+    {% endif %}
   {% endblock -%}
 
 {% endif %}

--- a/ckanext/feedback/templates/utilization/details.html
+++ b/ckanext/feedback/templates/utilization/details.html
@@ -68,16 +68,20 @@
           <h4>{{ _('Comments') }}</h4>
           <p>{{ row.comment }}</p>
           <hr>
-          <form name="comment_form" action="{{ url_for('utilization.create_comment', utilization_id=utilization_id ) }}" method="post">
+          <form id="comment_form" name="comment_form" action="{{ url_for('utilization.create_comment', utilization_id=utilization_id ) }}" method="post">
             <h4>{{ _('Comment') }}</h4>
             <select name="category" id="category">
               {% for category in categories %}
+                {% if category.name == selected_category %}
+                <option value="{{ category.name }}" selected>{{ _(category.value) }}</option>
+                {% else %}
                 <option value="{{ category.name }}">{{ _(category.value) }}</option>
+                {% endif %}
               {% endfor %}
             </select>
             <br>
             <br>
-            <textarea class="form-control" cols="20" rows="5" id="comment-content" name="content"></textarea>
+            <textarea class="form-control" cols="20" rows="5" id="comment-content" name="content">{{ content }}</textarea>
             <div>
               <p id="content-error" class="alert alert-error" style="display: none;">{{ _('Please enter your comment') }}</p>
             </div>
@@ -190,6 +194,15 @@
   {%- block scripts %}
     {{ super() }}
     {% asset 'feedback/feedback-detail-js' %}
+    {% if h.is_enabled_feedback_recaptcha %}
+      <script src="https://www.google.com/recaptcha/api.js?render={{ h.get_feedback_recaptcha_publickey() }}"></script>
+      <script>
+        let feedback_recaptcha_target_form = 'comment_form'
+        let feedback_recaptcha_action = 'utilization_comment'
+        let feedback_recaptcha_publickey = '{{ h.get_feedback_recaptcha_publickey() }}'
+      </script>
+      {% asset 'feedback/feedback-recaptcha-js'%}
+    {% endif %}
   {% endblock -%}
 
 {% endif %}

--- a/ckanext/feedback/templates/utilization/details.html
+++ b/ckanext/feedback/templates/utilization/details.html
@@ -197,9 +197,9 @@
     {% if h.is_enabled_feedback_recaptcha %}
       <script src="https://www.google.com/recaptcha/api.js?render={{ h.get_feedback_recaptcha_publickey() }}"></script>
       <script>
-        let feedback_recaptcha_target_form = 'comment_form'
-        let feedback_recaptcha_action = 'utilization_comment'
-        let feedback_recaptcha_publickey = '{{ h.get_feedback_recaptcha_publickey() }}'
+        const feedbackRecaptchaTargetForm = 'comment_form'
+        const feedbackRecaptchaAction = 'utilization_comment'
+        const feedbackRecaptchaPublickey = '{{ h.get_feedback_recaptcha_publickey() }}'
       </script>
       {% asset 'feedback/feedback-recaptcha-js'%}
     {% endif %}

--- a/ckanext/feedback/templates/utilization/new.html
+++ b/ckanext/feedback/templates/utilization/new.html
@@ -33,7 +33,7 @@
           <input type="hidden" id="package_name" name="package_name" value="{{ pkg_dict.name }}">
           <input type="hidden" id="resource_id" name="resource_id" value="{{ resource.id }}">
           <h4>{{ _('Title') }}</h4>
-          <input type="text" class="form-control" id="title" name="title"/>
+          <input type="text" class="form-control" id="title" name="title" value="{{ title }}"/>
           <div>
             <p id="title-error" class="alert alert-error" style="display: none;">{{ _('Please enter a title') }}</p>
           </div>
@@ -45,7 +45,7 @@
           <br>
           <hr>
           <h4>{{ _('Description') }}</h4>
-          <textarea class="form-control" cols="20" rows="5" id="description" name="description"></textarea>
+          <textarea class="form-control" cols="20" rows="5" id="description" name="description">{{ description }}</textarea>
           <div>
             <p id="description-error" class="alert alert-error" style="display: none;">{{ _('Please enter a description') }}</p>
           </div>

--- a/ckanext/feedback/templates/utilization/new.html
+++ b/ckanext/feedback/templates/utilization/new.html
@@ -66,9 +66,9 @@
     {% if h.is_enabled_feedback_recaptcha %}
       <script src="https://www.google.com/recaptcha/api.js?render={{ h.get_feedback_recaptcha_publickey() }}"></script>
       <script>
-        let feedback_recaptcha_target_form = 'content_form'
-        let feedback_recaptcha_action = 'utilization_new'
-        let feedback_recaptcha_publickey = '{{ h.get_feedback_recaptcha_publickey() }}'
+        const feedbackRecaptchaTargetForm = 'content_form'
+        const feedbackRecaptchaAction = 'utilization_new'
+        const feedbackRecaptchaPublickey = '{{ h.get_feedback_recaptcha_publickey() }}'
       </script>
       {% asset 'feedback/feedback-recaptcha-js'%}
     {% endif %}

--- a/ckanext/feedback/templates/utilization/new.html
+++ b/ckanext/feedback/templates/utilization/new.html
@@ -28,7 +28,7 @@
           <a href="{{ h.url_for('resource.read', id=pkg_dict.name, resource_id=resource.id) }}">{{ resource.name }}</a>
           <hr>
         </div>
-        <form name="content_form" action="{{ url_for('utilization.create') }}" method="post">
+        <form id="content_form" name="content_form" action="{{ url_for('utilization.create') }}" method="post">
           <input type="hidden" id="return_to_resource" name="return_to_resource" value="{{ return_to_resource }}">
           <input type="hidden" id="package_name" name="package_name" value="{{ pkg_dict.name }}">
           <input type="hidden" id="resource_id" name="resource_id" value="{{ resource.id }}">
@@ -63,6 +63,15 @@
   {%- block scripts %}
     {{ super() }}
     {% asset 'feedback/feedback-registration-js' %}
+    {% if h.is_enabled_feedback_recaptcha %}
+      <script src="https://www.google.com/recaptcha/api.js?render={{ h.get_feedback_recaptcha_publickey() }}"></script>
+      <script>
+        let feedback_recaptcha_target_form = 'content_form'
+        let feedback_recaptcha_action = 'utilization_new'
+        let feedback_recaptcha_publickey = '{{ h.get_feedback_recaptcha_publickey() }}'
+      </script>
+      {% asset 'feedback/feedback-recaptcha-js'%}
+    {% endif %}
   {% endblock -%}
 
 {% endif %}

--- a/docs/ja/google_recaptcha.md
+++ b/docs/ja/google_recaptcha.md
@@ -1,0 +1,27 @@
+# google_reCAPTCHA
+
+各種投稿のスパム対策機能です。</br>
+以下の投稿実行時に Google reCAPTCHA v3 を使用した検証を行い、算出されたscoreが閾値未満の場合はユーザへ投稿実行の再試行を要求します。
+
+- Utilization投稿
+- Utilizationコメント投稿
+- Resourceコメント投稿
+
+## 設定方法
+`ckan.ini`内にて以下の設定項目を追記する事で有効化されます。</br>
+また、必要なサイトキー、シークレットキーは、[公式ガイド](https://developers.google.com/recaptcha/intro?hl=ja)に従ってv3のものを取得してください。
+
+```ini
+ckan.feedback.recaptcha.enable = true
+ckan.feedback.recaptcha.publickey = サイトキー
+ckan.feedback.recaptcha.privatekey = シークレットキー
+```
+
+また、閾値に関しては内部的に独自のデフォルト値として0.5が設定されています。そのため、検証結果の score が 0.5 未満の場合はユーザに再試行を要求しますが、閾値を任意の値に変更したい場合は以下の設定項目を追記してください。
+
+```ini
+ckan.feedback.recaptcha.score_threshold = 0.0 ~ 1.0
+```
+
+適切な閾値を判断する方法については [公式ドキュメント スコアの解釈](https://developers.google.com/recaptcha/docs/v3?hl=ja#interpreting_the_score)を参照してください。</br>
+その他、google reACAPTCHA v3の詳しい仕様については[公式ドキュメント](https://developers.google.com/recaptcha/docs/v3?hl=ja)を参照してください。


### PR DESCRIPTION
## 概要
スパム対策として[reCAPTCHA v3](https://developers.google.com/recaptcha/docs/v3?hl=ja)を以下の投稿に対して適用。
- utilization投稿
- utilizationコメント投稿
- resourceコメント投稿

## 処理
フロントエンドから取得したreCAPTCHAのレスポンストークンをバックエンドにて検証しscoreを算出する。
scoreが閾値未満の場合、botによる投稿の可能性があると判断して、クライアントに投稿の再試行を求める。

## 参考
- [既存実装1](https://github.com/ckan/ckan/blob/master/ckan/views/user.py#L467-L472)
- [既存実装2](https://github.com/ckan/ckan/blob/master/ckan/lib/captcha.py)