### PR TITLE
リソースのコメント承認ボタンの位置修正

### DIFF
--- a/ckanext/feedback/templates/resource/comment.html
+++ b/ckanext/feedback/templates/resource/comment.html
@@ -97,7 +97,11 @@
                 {% endif %}
               {% else %}
                 <form name="approval_form" action="{{ url_for('resource_comment.approve_comment', resource_id=resource.id ) }}" method="post">
-                  <button class="btn btn-primary float-end" id="resource_comment_id" name="resource_comment_id" value="{{ comment.id }}">{{ _('Approve') }}</button>
+                  {% if h.is_base_public_folder_bs3() %}
+                    <button class="btn btn-primary pull-right" id="resource_comment_id" name="resource_comment_id" value="{{ comment.id }}">{{ _('Approve') }}</button>
+                  {% else %}
+                    <button class="btn btn-primary float-end" id="resource_comment_id" name="resource_comment_id" value="{{ comment.id }}">{{ _('Approve') }}</button>
+                  {% endif %}
                 </form>
               {% endif %}
             {% endif %}


### PR DESCRIPTION
リソースのコメント承認ボタンにおいて、Bootstrap3系への対応が漏れていた。
上記の場所へ[164のPR](https://github.com/c-3lab/ckanext-feedback/pull/164)で行った変更を適応した。