### PR TITLE
利活用方法 詳細画面のURL 遷移エラー

### DIFF
--- a/ckanext/feedback/controllers/resource.py
+++ b/ckanext/feedback/controllers/resource.py
@@ -14,8 +14,8 @@ from ckanext.feedback.services.common.check import (
     check_administrator,
     has_organization_admin_role,
 )
-from ckanext.feedback.services.recaptcha.check import is_recaptcha_verified
 from ckanext.feedback.services.common.send_mail import send_email
+from ckanext.feedback.services.recaptcha.check import is_recaptcha_verified
 
 log = logging.getLogger(__name__)
 

--- a/ckanext/feedback/controllers/utilization.py
+++ b/ckanext/feedback/controllers/utilization.py
@@ -13,6 +13,7 @@ import ckanext.feedback.services.utilization.edit as edit_service
 import ckanext.feedback.services.utilization.registration as registration_service
 import ckanext.feedback.services.utilization.search as search_service
 import ckanext.feedback.services.utilization.summary as summary_service
+import ckanext.feedback.services.utilization.validate as validate_service
 from ckanext.feedback.models.session import session
 from ckanext.feedback.services.common.check import (
     check_administrator,
@@ -115,6 +116,16 @@ class UtilizationController:
         title = request.form.get('title', '')
         url = request.form.get('url', '')
         description = request.form.get('description', '')
+
+        if url and not validate_service.validate_url(url):
+            helpers.flash_error(
+                _(
+                    'Please provide a valid URL'
+                ),
+                allow_html=True,
+            )
+            return UtilizationController.new(resource_id, title, description)
+
         if not (resource_id and title and description):
             toolkit.abort(400)
 
@@ -308,6 +319,15 @@ class UtilizationController:
         description = request.form.get('description', '')
         if not (title and description):
             toolkit.abort(400)
+
+        if url and not validate_service.validate_url(url):
+            helpers.flash_error(
+                _(
+                    'Please provide a valid URL'
+                ),
+                allow_html=True,
+            )
+            return UtilizationController.edit(utilization_id)
 
         edit_service.update_utilization(utilization_id, title, url, description)
         session.commit()

--- a/ckanext/feedback/controllers/utilization.py
+++ b/ckanext/feedback/controllers/utilization.py
@@ -20,8 +20,8 @@ from ckanext.feedback.services.common.check import (
     has_organization_admin_role,
     is_organization_admin,
 )
-from ckanext.feedback.services.recaptcha.check import is_recaptcha_verified
 from ckanext.feedback.services.common.send_mail import send_email
+from ckanext.feedback.services.recaptcha.check import is_recaptcha_verified
 
 log = logging.getLogger(__name__)
 
@@ -119,9 +119,7 @@ class UtilizationController:
 
         if url and not validate_service.validate_url(url):
             helpers.flash_error(
-                _(
-                    'Please provide a valid URL'
-                ),
+                _('Please provide a valid URL'),
                 allow_html=True,
             )
             return UtilizationController.new(resource_id, title, description)
@@ -322,9 +320,7 @@ class UtilizationController:
 
         if url and not validate_service.validate_url(url):
             helpers.flash_error(
-                _(
-                    'Please provide a valid URL'
-                ),
+                _('Please provide a valid URL'),
                 allow_html=True,
             )
             return UtilizationController.edit(utilization_id)

--- a/ckanext/feedback/controllers/utilization.py
+++ b/ckanext/feedback/controllers/utilization.py
@@ -117,7 +117,7 @@ class UtilizationController:
         url = request.form.get('url', '')
         description = request.form.get('description', '')
 
-        if url and not validate_service.validate_url(url):
+        if url and validate_service.validate_url(url):
             helpers.flash_error(
                 _('Please provide a valid URL'),
                 allow_html=True,
@@ -318,7 +318,7 @@ class UtilizationController:
         if not (title and description):
             toolkit.abort(400)
 
-        if url and not validate_service.validate_url(url):
+        if url and validate_service.validate_url(url):
             helpers.flash_error(
                 _('Please provide a valid URL'),
                 allow_html=True,

--- a/ckanext/feedback/i18n/ja/LC_MESSAGES/ckanext-feedback.po
+++ b/ckanext/feedback/i18n/ja/LC_MESSAGES/ckanext-feedback.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-feedback 1.2.0\n"
 "Report-Msgid-Bugs-To: info.c3lab@gmail.com\n"
-"POT-Creation-Date: 2024-05-29 13:04+0900\n"
+"POT-Creation-Date: 2024-06-11 09:37+0900\n"
 "PO-Revision-Date: 2023-03-01 14:16+0900\n"
 "Last-Translator: c3Lab <info.c3lab@gmail.com>\n"
 "Language: ja\n"
@@ -72,7 +72,7 @@ msgstr "一括削除完了"
 #: ckanext/feedback/controllers/management.py:144
 #: ckanext/feedback/controllers/management.py:161
 #: ckanext/feedback/controllers/resource.py:160
-#: ckanext/feedback/controllers/utilization.py:365
+#: ckanext/feedback/controllers/utilization.py:381
 #: ckanext/feedback/services/common/check.py:13
 #: ckanext/feedback/tests/controllers/test_management.py:574
 #: ckanext/feedback/tests/controllers/test_management.py:652
@@ -89,29 +89,34 @@ msgid ""
 msgstr "要求された URL がサーバー上に見つかりませんでした。URL を手動で入力した場合は、綴りを確認してからもう一度お試しください。"
 
 #: ckanext/feedback/controllers/resource.py:79
-#: ckanext/feedback/controllers/utilization.py:122
-#: ckanext/feedback/controllers/utilization.py:225
+#: ckanext/feedback/controllers/utilization.py:131
+#: ckanext/feedback/controllers/utilization.py:234
 msgid "Bad Captcha. Please try again."
 msgstr "認証に失敗しました。 もう一度お試しください。"
 
 #: ckanext/feedback/controllers/resource.py:107
-#: ckanext/feedback/controllers/utilization.py:254
+#: ckanext/feedback/controllers/utilization.py:263
 msgid ""
 "Your comment has been sent.<br>The comment will not be displayed until "
 "approved by an administrator."
 msgstr "コメント送信が完了しました。<br>管理者にコメントが承認されるまで表示されません。"
 
-#: ckanext/feedback/controllers/utilization.py:152
+#: ckanext/feedback/controllers/utilization.py:122
+#: ckanext/feedback/controllers/utilization.py:323
+msgid "Please provide a valid URL"
+msgstr "有効なURLを入力してください。"
+
+#: ckanext/feedback/controllers/utilization.py:161
 msgid ""
 "Your application is complete.<br>The utilization will not be displayed "
 "until approved by an administrator."
 msgstr "登録申請が完了しました。<br>管理者に申請が承認されるまで表示されません。"
 
-#: ckanext/feedback/controllers/utilization.py:316
+#: ckanext/feedback/controllers/utilization.py:332
 msgid "The utilization has been successfully updated."
 msgstr "利活用方法の更新に成功しました。"
 
-#: ckanext/feedback/controllers/utilization.py:333
+#: ckanext/feedback/controllers/utilization.py:349
 msgid "The utilization has been successfully deleted."
 msgstr "利活用方法の削除に成功しました。"
 

--- a/ckanext/feedback/services/recaptcha/check.py
+++ b/ckanext/feedback/services/recaptcha/check.py
@@ -27,12 +27,12 @@ def _check_recaptcha_v3_base(request: Request) -> None:
     client_ip_address = request.remote_addr or 'Unknown IP Address'
     recaptcha_response = request.form.get('g-recaptcha-response', '')
     if not recaptcha_response:
-        logger.warning("not recaptcha_response")
+        logger.warning('not recaptcha_response')
         raise CaptchaError()
 
     recaptcha_private_key = config.get('ckan.feedback.recaptcha.privatekey')
     if not recaptcha_private_key:
-        logger.warning("not recaptcha_private_key")
+        logger.warning('not recaptcha_private_key')
         raise CaptchaError()
 
     # reCAPTCHA v3
@@ -54,19 +54,19 @@ def _check_recaptcha_v3_base(request: Request) -> None:
 
     try:
         if not data['success']:
-            logger.warning(f"not success:{data}")
+            logger.warning(f'not success:{data}')
             raise CaptchaError()
         if data['score'] < score_threshold:
             logger.warning(
-                f"Score is below the threshold:{data}:score_threshold={score_threshold}"
+                f'Score is below the threshold:{data}:score_threshold={score_threshold}'
             )
             raise CaptchaError()
     except IndexError:
         # Something weird with recaptcha response
-        logger.error("IndexError")
+        logger.error('IndexError')
         raise CaptchaError()
 
-    logger.info(f"reCAPTCHA verification passed successfully:{data}")
+    logger.info(f'reCAPTCHA verification passed successfully:{data}')
 
 
 def is_recaptcha_verified(request: Request):

--- a/ckanext/feedback/services/utilization/validate.py
+++ b/ckanext/feedback/services/utilization/validate.py
@@ -1,10 +1,10 @@
-from ckan.logic import get_validator
+import ckan.logic.validators as validators
 
 
 def validate_url(url):
     errors = {'key': []}
     context = {}
-    get_validator('url_validator')('key', {'key': url}, errors, context)
+    validators.url_validator('key', {'key': url}, errors, context)
     if errors['key']:
         return False
     return True

--- a/ckanext/feedback/services/utilization/validate.py
+++ b/ckanext/feedback/services/utilization/validate.py
@@ -1,0 +1,10 @@
+from ckan.logic import get_validator
+
+
+def validate_url(url):
+    errors = {'key': []}
+    context = {}
+    get_validator('url_validator')('key', {'key': url}, errors, context)
+    if errors['key']:
+        return False
+    return True

--- a/ckanext/feedback/services/utilization/validate.py
+++ b/ckanext/feedback/services/utilization/validate.py
@@ -5,6 +5,4 @@ def validate_url(url):
     errors = {'key': []}
     context = {}
     validators.url_validator('key', {'key': url}, errors, context)
-    if errors['key']:
-        return False
-    return True
+    return errors['key']

--- a/ckanext/feedback/templates/utilization/edit.html
+++ b/ckanext/feedback/templates/utilization/edit.html
@@ -38,7 +38,7 @@
           <hr>
           <small>{{ _('※ option') }}</small>
           <h4>{{ _('URL (Example : The URL for your Website or Service)') }}</h4>
-          <input type="text" class="form-control" id="url" name="url" value="{{ utilization_details.url }}" placeholder="https://example.com"/>
+          <input type="url" class="form-control" id="url" name="url" value="{{ utilization_details.url }}" placeholder="https://example.com"/>
           <br>
           <hr>
           <h4>{{ _('Description') }}</h4>

--- a/ckanext/feedback/templates/utilization/edit.html
+++ b/ckanext/feedback/templates/utilization/edit.html
@@ -38,7 +38,7 @@
           <hr>
           <small>{{ _('※ option') }}</small>
           <h4>{{ _('URL (Example : The URL for your Website or Service)') }}</h4>
-          <input type="text" class="form-control" id="url" name="url" value="{{ utilization_details.url }}"/>
+          <input type="text" class="form-control" id="url" name="url" value="{{ utilization_details.url }}" placeholder="https://example.com"/>
           <br>
           <hr>
           <h4>{{ _('Description') }}</h4>

--- a/ckanext/feedback/templates/utilization/new.html
+++ b/ckanext/feedback/templates/utilization/new.html
@@ -41,7 +41,7 @@
           <hr>
           <small>{{ _('※ option') }}</small>
           <h4>{{ _('URL (Example : The URL for your Website or Service)') }}</h4>
-          <input type="text" class="form-control" id="url" name="url"/>
+          <input type="text" class="form-control" id="url" name="url" placeholder="https://example.com"/>
           <br>
           <hr>
           <h4>{{ _('Description') }}</h4>

--- a/ckanext/feedback/templates/utilization/new.html
+++ b/ckanext/feedback/templates/utilization/new.html
@@ -41,7 +41,7 @@
           <hr>
           <small>{{ _('※ option') }}</small>
           <h4>{{ _('URL (Example : The URL for your Website or Service)') }}</h4>
-          <input type="text" class="form-control" id="url" name="url" placeholder="https://example.com"/>
+          <input type="url" class="form-control" id="url" name="url" placeholder="https://example.com"/>
           <br>
           <hr>
           <h4>{{ _('Description') }}</h4>

--- a/ckanext/feedback/tests/controllers/test_utilization.py
+++ b/ckanext/feedback/tests/controllers/test_utilization.py
@@ -375,6 +375,92 @@ class TestUtilizationController:
 
         mock_toolkit_abort.assert_called_once_with(400)
 
+    @patch('ckanext.feedback.controllers.utilization.request.form')
+    @patch('ckanext.feedback.controllers.utilization.validate_service')
+    @patch('ckanext.feedback.controllers.utilization.registration_service')
+    @patch('ckanext.feedback.controllers.utilization.summary_service')
+    @patch('ckanext.feedback.controllers.utilization.session.commit')
+    @patch('ckanext.feedback.controllers.utilization.helpers.flash_success')
+    @patch('ckanext.feedback.controllers.utilization.url_for')
+    @patch('ckanext.feedback.controllers.utilization.redirect')
+    def test_create_with_valid_url(
+        self,
+        mock_redirect,
+        mock_url_for,
+        mock_flash_success,
+        mock_session_commit,
+        mock_summary_service,
+        mock_registration_service,
+        mock_validate_service,
+        mock_form,
+    ):
+        package_name = 'package'
+        resource_id = 'resource id'
+        title = 'title'
+        valid_url = 'https://example.com'
+        description = 'description'
+        return_to_resource = True
+
+        mock_form.get.side_effect = [
+            package_name,
+            resource_id,
+            title,
+            valid_url,
+            description,
+            return_to_resource,
+        ]
+        mock_url_for.return_value = 'resource read url'
+        mock_validate_service.validate_url.return_value = []
+
+        UtilizationController.create()
+
+        mock_validate_service.validate_url.assert_called_once_with(
+            valid_url
+        )
+        mock_registration_service.create_utilization.assert_called_with(
+            resource_id, title, valid_url, description
+        )
+        mock_summary_service.create_utilization_summary.assert_called_with(resource_id)
+        mock_session_commit.assert_called_once()
+        mock_flash_success.assert_called_once()
+        mock_url_for.assert_called_once_with(
+            'resource.read', id=package_name, resource_id=resource_id
+        )
+        mock_redirect.assert_called_with('resource read url')
+
+    @patch('ckanext.feedback.controllers.utilization.request.form')
+    @patch('ckanext.feedback.controllers.utilization.UtilizationController.new')
+    @patch('ckanext.feedback.controllers.utilization.validate_service')
+    @patch('ckanext.feedback.controllers.utilization.helpers.flash_error')
+    def test_create_with_invalid_url(
+        self,
+        mock_flash_error,
+        mock_validate_service,
+        mock_new,
+        mock_form,
+    ):
+        package_name = 'package'
+        resource_id = 'resource id'
+        title = 'title'
+        invalid_url = 'invalid_url'
+        description = 'description'
+        return_to_resource = True
+
+        mock_form.get.side_effect = [
+            package_name,
+            resource_id,
+            title,
+            invalid_url,
+            description,
+            return_to_resource,
+        ]
+        mock_validate_service.validate_url.return_value = ['Please provide a valid URL']
+
+        UtilizationController.create()
+
+        mock_flash_error.assert_called_once()
+        mock_new.assert_called_once_with(resource_id, title, description)
+
     @patch('flask_login.utils._get_user')
     @patch('ckanext.feedback.controllers.utilization.detail_service')
     @patch('ckanext.feedback.controllers.utilization.toolkit.render')

--- a/ckanext/feedback/tests/controllers/test_utilization.py
+++ b/ckanext/feedback/tests/controllers/test_utilization.py
@@ -414,9 +414,7 @@ class TestUtilizationController:
 
         UtilizationController.create()
 
-        mock_validate_service.validate_url.assert_called_once_with(
-            valid_url
-        )
+        mock_validate_service.validate_url.assert_called_once_with(valid_url)
         mock_registration_service.create_utilization.assert_called_with(
             resource_id, title, valid_url, description
         )

--- a/ckanext/feedback/tests/services/utilization/test_validate.py
+++ b/ckanext/feedback/tests/services/utilization/test_validate.py
@@ -26,6 +26,6 @@ class TestUtilizationDetailsService:
         assert result == []
 
     def test_validate_with_invalid_url(self):
-        example_invalid_url = "invalid_url"
+        example_invalid_url = 'invalid_url'
         result = validate_url(example_invalid_url)
         assert result == ['Please provide a valid URL']

--- a/ckanext/feedback/tests/services/utilization/test_validate.py
+++ b/ckanext/feedback/tests/services/utilization/test_validate.py
@@ -1,0 +1,31 @@
+import pytest
+from ckan import model
+
+from ckanext.feedback.command.feedback import (
+    create_download_tables,
+    create_resource_tables,
+    create_utilization_tables,
+)
+from ckanext.feedback.services.utilization.validate import validate_url
+
+engine = model.repo.session.get_bind()
+
+
+@pytest.mark.usefixtures('clean_db', 'with_plugins', 'with_request_context')
+class TestUtilizationDetailsService:
+    @classmethod
+    def setup_class(cls):
+        model.repo.init_db()
+        create_utilization_tables(engine)
+        create_resource_tables(engine)
+        create_download_tables(engine)
+
+    def test_validate_with_valid_url(self):
+        example_valid_url = 'https://example.com'
+        result = validate_url(example_valid_url)
+        assert result == []
+
+    def test_validate_with_invalid_url(self):
+        example_invalid_url = "invalid_url"
+        result = validate_url(example_invalid_url)
+        assert result == ['Please provide a valid URL']


### PR DESCRIPTION
* URLのバリデーションを追加しました。
* URLの例をPlaceholderとして表示するようにしました。
* 軽微なフォーマットの修正を行いました。
* `.po`ファイルの修正を行いました。