### PR TITLE
課題解決認定のある利活用の削除時エラーの解消

### DIFF
--- a/ckanext/feedback/controllers/utilization.py
+++ b/ckanext/feedback/controllers/utilization.py
@@ -344,6 +344,7 @@ class UtilizationController:
         UtilizationController._check_organization_admin_role(utilization_id)
         resource_id = detail_service.get_utilization(utilization_id).resource_id
         edit_service.delete_utilization(utilization_id)
+        session.commit()
         summary_service.refresh_utilization_summary(resource_id)
         session.commit()
 


### PR DESCRIPTION
利活用方法の削除後のsummary更新時の.count()が呼び出されるタイミングでセッションがautoflushされてしまい、意図しないupdateが発生したため、利活用方法の削除後に一度変更をDBに反映する修正。