### PR TITLE
CIにリンター、フォーマッターを追加

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,35 @@
+name: Lint
+on: [push, pull_request]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Install Python 3.10.13
+        uses: actions/setup-python@v4
+        with:
+            python-version: "3.10.13"
+
+      - name: Check out
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: true
+    
+      - name: Install Poetry
+        run: |
+          pip install poetry
+
+      - name: Install dependencies
+        run: |
+          poetry install
+        env:
+          POETRY_VIRTUALENVS_IN_PROJECT: true
+
+      - name: Install pre-commit
+        run: |
+          poetry run pre-commit install
+  
+      - name: Run pre-commit for Flake8, Black, isort
+        run: |
+          poetry run pre-commit run --all-files

--- a/ckanext/feedback/services/management/comments.py
+++ b/ckanext/feedback/services/management/comments.py
@@ -87,13 +87,15 @@ def refresh_resources_comments(resource_comment_summaries):
             rating = 0
         else:
             rating = row.total_rating / row.total_rating_comment
-        mappings.append({
-            'id': resource_comment_summary.id,
-            'comment': row.total_comment,
-            'rating_comment': row.total_rating_comment,
-            'rating': rating,
-            'updated': datetime.now(),
-        })
+        mappings.append(
+            {
+                'id': resource_comment_summary.id,
+                'comment': row.total_comment,
+                'rating_comment': row.total_rating_comment,
+                'rating': rating,
+                'updated': datetime.now(),
+            }
+        )
     session.bulk_update_mappings(ResourceCommentSummary, mappings)
 
 

--- a/ckanext/feedback/tests/services/management/test_comments.py
+++ b/ckanext/feedback/tests/services/management/test_comments.py
@@ -205,10 +205,12 @@ class TestComments:
         session.commit()
 
         mock_get_utilization_comments.return_value = 0
-        comments.refresh_utilizations_comments([
-            get_registered_utilization(resource['id'])[0],
-            get_registered_utilization(resource['id'])[1],
-        ])
+        comments.refresh_utilizations_comments(
+            [
+                get_registered_utilization(resource['id'])[0],
+                get_registered_utilization(resource['id'])[1],
+            ]
+        )
 
         expected_args = (
             Utilization,
@@ -378,12 +380,14 @@ class TestComments:
 
         expected_args = (
             UtilizationComment,
-            [{
-                'id': comment_id,
-                'approval': True,
-                'approved': datetime.now(),
-                'approval_user_id': None,
-            }],
+            [
+                {
+                    'id': comment_id,
+                    'approval': True,
+                    'approved': datetime.now(),
+                    'approval_user_id': None,
+                }
+            ],
         )
 
         assert mock_mappings.call_args[0] == expected_args
@@ -435,12 +439,14 @@ class TestComments:
 
         expected_args = (
             ResourceComment,
-            [{
-                'id': resource_comment[0].id,
-                'approval': True,
-                'approved': datetime.now(),
-                'approval_user_id': None,
-            }],
+            [
+                {
+                    'id': resource_comment[0].id,
+                    'approval': True,
+                    'approved': datetime.now(),
+                    'approval_user_id': None,
+                }
+            ],
         )
 
         assert mock_mappings.call_args[0] == expected_args


### PR DESCRIPTION
- #148 への対応として、CIにリンター、フォーマッターを追加した
- 具体的には、push または PR 時、github actions で flake8, black, isort を全ソースファイルに対して実施するようにした