### PR TITLE
ダウンロード時のファイル名修正

### DIFF
--- a/ckanext/feedback/controllers/download.py
+++ b/ckanext/feedback/controllers/download.py
@@ -5,6 +5,7 @@ from flask import request
 
 from ckanext.feedback.services.common import config as feedback_config
 from ckanext.feedback.services.download.summary import increment_resource_downloads
+from ckanext.feedback.services.resource.comment import get_resource
 
 log = logging.getLogger(__name__)
 
@@ -13,6 +14,9 @@ class DownloadController:
     # extend default download function to count when a resource is downloaded
     @staticmethod
     def extended_download(package_type, id, resource_id, filename=None):
+        if filename is None:
+            filename = get_resource(resource_id).Resource.url
+
         if request.headers.get('Sec-Fetch-Dest') == 'document':
             increment_resource_downloads(resource_id)
 

--- a/ckanext/feedback/tests/controllers/test_download.py
+++ b/ckanext/feedback/tests/controllers/test_download.py
@@ -40,7 +40,9 @@ class TestDownloadController:
     @patch('ckanext.feedback.controllers.download.feedback_config.download_handler')
     @patch('ckanext.feedback.controllers.download.resource.download')
     def test_extended_download(self, mock_download, mock_download_handler):
-        resource = factories.Resource()
+        owner_org = factories.Organization()
+        dataset = factories.Dataset(owner_org=owner_org['id'])
+        resource = factories.Resource(package_id=dataset['id'])
         mock_download_handler.return_value = None
 
         with self.app.test_request_context(headers={'Sec-Fetch-Dest': 'document'}):
@@ -52,7 +54,7 @@ class TestDownloadController:
                 package_type='package_type',
                 id=resource['package_id'],
                 resource_id=resource['id'],
-                filename=None,
+                filename=resource['url'],
             )
 
     @patch('ckanext.feedback.controllers.download.resource.download')
@@ -60,7 +62,7 @@ class TestDownloadController:
         resource = factories.Resource()
         with self.app.test_request_context(headers={'Sec-Fetch-Dest': 'image'}):
             DownloadController.extended_download(
-                'package_type', resource['package_id'], resource['id'], None
+                'package_type', resource['package_id'], resource['id'], resource['url']
             )
             assert get_downloads(resource['id']) is None
             assert mock_download
@@ -74,11 +76,11 @@ class TestDownloadController:
         mock_download_handler.return_value = handler
         with self.app.test_request_context(headers={'Sec-Fetch-Dest': 'image'}):
             DownloadController.extended_download(
-                'package_type', resource['package_id'], resource['id'], None
+                'package_type', resource['package_id'], resource['id'], resource['url']
             )
             handler.assert_called_once_with(
                 package_type='package_type',
                 id=resource['package_id'],
                 resource_id=resource['id'],
-                filename=None,
+                filename=resource['url'],
             )

--- a/ckanext/feedback/tests/views/test_download.py
+++ b/ckanext/feedback/tests/views/test_download.py
@@ -44,12 +44,14 @@ class TestDownloadController:
         mock_extended_download.return_value = mock_extended_download
 
         # with self.app.test_request_context(headers={'Sec-Fetch-Dest': 'document'}):
-        download('package_type', resource['package_id'], resource['id'], None)
+        download(
+            'package_type', resource['package_id'], resource['id'], resource['url']
+        )
         mock_extended_download.assert_called_once_with(
             package_type='package_type',
             id=resource['package_id'],
             resource_id=resource['id'],
-            filename=None,
+            filename=resource['url'],
         )
 
     @patch('ckanext.feedback.views.download.feedback_config.download_handler')
@@ -61,12 +63,14 @@ class TestDownloadController:
         mock_download_handler.return_value = None
         config['ckan.feedback.downloads.enable'] = False
 
-        download('package_type', resource['package_id'], resource['id'], None)
+        download(
+            'package_type', resource['package_id'], resource['id'], resource['url']
+        )
         mock_download.assert_called_once_with(
             package_type='package_type',
             id=resource['package_id'],
             resource_id=resource['id'],
-            filename=None,
+            filename=resource['url'],
         )
 
     @patch('ckanext.feedback.views.download.feedback_config.download_handler')
@@ -74,7 +78,9 @@ class TestDownloadController:
     def test_download_false_with_set_download_handler(
         self, mock_extended_download, mock_download_handler
     ):
-        resource = factories.Resource()
+        owner_org = factories.Organization()
+        dataset = factories.Dataset(owner_org=owner_org['id'])
+        resource = factories.Resource(package_id=dataset['id'])
         mock_download_handler.return_value = mock_extended_download
         config['ckan.feedback.downloads.enable'] = False
 

--- a/ckanext/feedback/views/download.py
+++ b/ckanext/feedback/views/download.py
@@ -6,6 +6,7 @@ from flask import Blueprint
 
 from ckanext.feedback.controllers.download import DownloadController
 from ckanext.feedback.services.common import config as feedback_config
+from ckanext.feedback.services.resource.comment import get_resource
 from ckanext.feedback.views.error_handler import add_error_handler
 
 log = logging.getLogger(__name__)
@@ -33,6 +34,9 @@ def get_download_blueprint():
 
 # Handler to Use When Called from External Extensions
 def download(package_type, id, resource_id, filename=None):
+    if filename is None:
+        filename = get_resource(resource_id).Resource.url
+
     if config.get('ckan.feedback.downloads.enable', True):
         handler = DownloadController.extended_download
     else:


### PR DESCRIPTION
リソース登録時にURLではなくファイルがアップロードされたリソースが対象。
リソース登録時にアップロードされたファイル名をダウンロードするファイル名とする。