### PR TITLE
テンプレートに渡す組織名取得のバグ修正

### DIFF
--- a/ckanext/feedback/controllers/utilization.py
+++ b/ckanext/feedback/controllers/utilization.py
@@ -91,7 +91,7 @@ class UtilizationController:
         package = get_action('package_show')(
             context, {'id': resource.Resource.package.id}
         )
-        g.pkg_dict = {'organization': {'name': resource.Resource.organization_name}}
+        g.pkg_dict = {'organization': {'name': resource.organization_name}}
 
         return toolkit.render(
             'utilization/new.html',

--- a/ckanext/feedback/tests/controllers/test_management.py
+++ b/ckanext/feedback/tests/controllers/test_management.py
@@ -152,6 +152,7 @@ class TestManagementController:
                 'tab': 'utilization-comments',
             },
         )
+        assert g.pkg_dict['organization']['name'] is not None
 
     @patch('flask_login.utils._get_user')
     @patch('ckanext.feedback.controllers.management._')

--- a/ckanext/feedback/tests/controllers/test_utilization.py
+++ b/ckanext/feedback/tests/controllers/test_utilization.py
@@ -399,6 +399,7 @@ class TestUtilizationController:
                 'description': '',
             },
         )
+        assert g.pkg_dict['organization']['name'] == mock_organization['name']
 
     @patch('flask_login.utils._get_user')
     @patch('ckanext.feedback.controllers.utilization.toolkit.render')

--- a/ckanext/feedback/tests/controllers/test_utilization.py
+++ b/ckanext/feedback/tests/controllers/test_utilization.py
@@ -168,6 +168,7 @@ class TestUtilizationController:
                 'utilizations': mock_get_utilizations.return_value,
             },
         )
+        assert g.pkg_dict['organization']['name'] == organization.name
 
     @patch('flask_login.utils._get_user')
     @patch('ckanext.feedback.controllers.utilization.toolkit.render')
@@ -233,6 +234,7 @@ class TestUtilizationController:
         mock_dataset.owner_org = factories.Organization()['id']
         mock_resource = MagicMock()
         mock_resource.package = mock_dataset
+        mock_resource.organization_name = 'test_organization'
         mock_get_resource.return_value = mock_resource
 
         keyword = 'keyword'
@@ -259,6 +261,7 @@ class TestUtilizationController:
                 'utilizations': mock_get_utilizations.return_value,
             },
         )
+        assert g.pkg_dict['organization']['name'] == 'test_organization'
 
     @patch('ckanext.feedback.controllers.utilization.toolkit.render')
     @patch('ckanext.feedback.controllers.utilization.model.Group.get')
@@ -311,6 +314,7 @@ class TestUtilizationController:
                 'utilizations': mock_get_utilizations.return_value,
             },
         )
+        assert g.pkg_dict['organization']['name'] == mock_organization.name
 
     @patch('ckanext.feedback.controllers.utilization.toolkit.render')
     @patch('ckanext.feedback.controllers.utilization.model.Package.get')
@@ -880,6 +884,7 @@ class TestUtilizationController:
         mock_dataset.owner_org = mock_organization['id']
         mock_resource = MagicMock()
         mock_resource.package = mock_dataset
+        mock_resource.organization_name = 'test_organization'
         mock_get_resource.return_value = mock_resource
 
         UtilizationController.details(utilization_id)
@@ -904,6 +909,7 @@ class TestUtilizationController:
                 'content': '',
             },
         )
+        assert g.pkg_dict['organization']['name'] == 'test_organization'
 
     @patch('flask_login.utils._get_user')
     @patch('ckanext.feedback.controllers.utilization.detail_service')
@@ -1095,6 +1101,7 @@ class TestUtilizationController:
         mock_dataset.owner_org = mock_organization['id']
         mock_resource = MagicMock()
         mock_resource.package = mock_dataset
+        mock_resource.organization_name = 'test_organization'
         mock_get_resource.return_value = mock_resource
 
         g.userobj = current_user
@@ -1113,6 +1120,7 @@ class TestUtilizationController:
                 'resource_details': resource_details,
             },
         )
+        assert g.pkg_dict['organization']['name'] == 'test_organization'
 
     @patch('flask_login.utils._get_user')
     @patch('ckanext.feedback.controllers.utilization.request.form')


### PR DESCRIPTION
こちらの対応時に含まれたバグの修正。
https://github.com/c-3lab/ckanext-feedback/pull/197

該当バグの検出が出来なかったテストコードの修正を含む。