### PR TITLE
リソースコメント投稿後の画面遷移修正

### DIFF
--- a/ckanext/feedback/controllers/resource.py
+++ b/ckanext/feedback/controllers/resource.py
@@ -62,6 +62,7 @@ class ResourceController:
     # resource_comment/<resource_id>/comment/new
     @staticmethod
     def create_comment(resource_id):
+        package_name = request.form.get('package_name', '')
         category = None
         content = None
         if request.form.get('comment_content'):
@@ -110,8 +111,9 @@ class ResourceController:
         )
 
         resp = make_response(
-            redirect(url_for('resource_comment.comment', resource_id=resource_id))
+            redirect(url_for('resource.read', id=package_name, resource_id=resource_id))
         )
+
         resp.set_cookie(resource_id, 'alreadyPosted')
 
         return resp

--- a/ckanext/feedback/templates/resource/comment.html
+++ b/ckanext/feedback/templates/resource/comment.html
@@ -48,6 +48,7 @@
             <br>
             <form id="comment_form" name="comment_form" action="{{ url_for('resource_comment.create_comment', resource_id=resource.id ) }}" method="post">
               <input type="hidden" id="rating" name="rating" value=""/>
+              <input type="hidden" id="package_name" name="package_name" value="{{ pkg_dict.name }}">
               <select name="category" id="category">
                 {% for category in categories %}
                 {% if category.name == selected_category %}

--- a/ckanext/feedback/tests/controllers/test_resource.py
+++ b/ckanext/feedback/tests/controllers/test_resource.py
@@ -74,7 +74,7 @@ class TestResourceController:
             g.userobj = current_user
             ResourceController.comment(resource_id)
 
-        approval = True
+        approval = None
         resource = comment_service.get_resource(resource_id)
         comments = comment_service.get_resource_comments(resource_id, approval)
         categories = comment_service.get_resource_comment_categories()
@@ -198,7 +198,9 @@ class TestResourceController:
         category = 'category'
         comment_content = 'content'
         rating = '1'
+        package_name = 'ota'
         mock_form.get.side_effect = [
+            package_name,
             comment_content,
             comment_content,
             category,
@@ -223,7 +225,7 @@ class TestResourceController:
                 call(
                     'resource_comment.comment', resource_id=resource_id, _external=True
                 ),
-                call('resource_comment.comment', resource_id=resource_id),
+                call('resource.read', id=package_name, resource_id=resource_id),
             ]
         )
         mock_redirect.assert_called_once_with('resource comment')
@@ -254,6 +256,7 @@ class TestResourceController:
         resource_id = 'resource id'
         package_name = 'ota'
         mock_form.get.side_effect = [
+            package_name,
             None,
             None,
         ]
@@ -276,6 +279,7 @@ class TestResourceController:
         category = 'category'
         package_name = 'ota'
         mock_form.get.side_effect = [
+            package_name,
             comment_content,
             comment_content,
             category,

--- a/ckanext/feedback/tests/controllers/test_resource.py
+++ b/ckanext/feedback/tests/controllers/test_resource.py
@@ -252,6 +252,7 @@ class TestResourceController:
         mock_toolkit_abort,
     ):
         resource_id = 'resource id'
+        package_name = 'ota'
         mock_form.get.side_effect = [
             None,
             None,
@@ -273,7 +274,7 @@ class TestResourceController:
         resource_id = 'resource_id'
         comment_content = 'comment_content'
         category = 'category'
-
+        package_name = 'ota'
         mock_form.get.side_effect = [
             comment_content,
             comment_content,


### PR DESCRIPTION
リソースコメント投稿後にリソースコメント画面またはデータセット画面へ遷移するように実装しました。