### PR TITLE
不要なbtn-group属性を削除

### DIFF
--- a/ckanext/feedback/templates/package/resource_read.html
+++ b/ckanext/feedback/templates/package/resource_read.html
@@ -53,20 +53,16 @@
   </li>
   {% if h.is_enabled_utilizations_org(pkg.owner_org) %}
     <li>
-      <div class="btn-group">
-        <a class="btn btn-primary resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ h.url_for('utilization.new', package_name=pkg.name, resource_id=res.id, return_to_resource=true) }}">
-          <i class="fa-solid fa-seedling"></i> {{ _('Create utilization application') }}
-        </a>
-      </div>
+      <a class="btn btn-primary resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ h.url_for('utilization.new', package_name=pkg.name, resource_id=res.id, return_to_resource=true) }}">
+        <i class="fa-solid fa-seedling"></i> {{ _('Create utilization application') }}
+      </a>
     </li>
   {% endif %}
   {% if h.is_enabled_resources_org(pkg.owner_org) %}
     <li>
-      <div class="btn-group">
-        <a class="btn btn-primary resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ h.url_for('resource_comment.comment', resource_id=res.id) }}">
-          <i class="fa-solid fa-comment-dots"></i> {{ _('Comment') }}
-        </a>
-      </div>
+      <a class="btn btn-primary resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ h.url_for('resource_comment.comment', resource_id=res.id) }}">
+        <i class="fa-solid fa-comment-dots"></i> {{ _('Comment') }}
+      </a>
     </li>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
リソース詳細画面でボタンの形が崩れることがある問題の対応。
リソース詳細画面以外では問題ないことを確認済み。