### PR TITLE
データセットのリソースアイコンとフィードバックアイコンを改行で分割する修正

### DIFF
--- a/ckanext/feedback/templates/snippets/package_item.html
+++ b/ckanext/feedback/templates/snippets/package_item.html
@@ -12,6 +12,7 @@
       {% endif %}
     </li>
   {% endfor %}
+  <br>
   <li>
     {% if h.is_enabled_downloads_org(package.owner_org) %}
       <div class = "bubble">


### PR DESCRIPTION
#### 概要
データソースのリソースを表すアイコン（CSV、PNGなど）と、ckanext-feedbackのアイコン（ダウンロード数、利活用数など）が横並びに並んでいた。  
このとき、リソースアイコンとフィードバックアイコンの水平位置にずれがあったため、  
リソースアイコンとフィードバックアイコンを改行で分割し表示するように修正した。
#### イメージ
![image](https://github.com/user-attachments/assets/4ded9f76-d825-45bd-afe2-425a5282b7fa)
