### PR TITLE
ダウンロード時にブラウザに表示されないようにする

### DIFF
--- a/ckanext/feedback/controllers/download.py
+++ b/ckanext/feedback/controllers/download.py
@@ -1,7 +1,10 @@
 import logging
+import os
+from urllib.parse import urlparse
 
 import ckan.views.resource as resource
-from flask import request
+import requests
+from flask import Response, request
 
 from ckanext.feedback.services.common import config as feedback_config
 from ckanext.feedback.services.download.summary import increment_resource_downloads
@@ -33,6 +36,18 @@ class DownloadController:
             resource_id=resource_id,
             filename=filename,
         )
+
+        if response._status_code == 302:
+            url = response.headers.get('Location')
+            log.debug(f"download to redirect URL.[{url}]")
+            filename = os.path.basename(urlparse(url).path)
+
+            redirect_response = requests.get(url, allow_redirects=True)
+            response = Response(
+                redirect_response.content,
+                headers=redirect_response.headers.__dict__,
+                content_type=redirect_response.headers['Content-Type'],
+            )
 
         c_d_value = response.headers.get('Content-Disposition')
         if c_d_value:

--- a/ckanext/feedback/controllers/download.py
+++ b/ckanext/feedback/controllers/download.py
@@ -27,9 +27,20 @@ class DownloadController:
         if not handler:
             log.debug('Use default CKAN callback for resource.download')
             handler = resource.download
-        return handler(
+        response = handler(
             package_type=package_type,
             id=id,
             resource_id=resource_id,
             filename=filename,
         )
+
+        c_d_value = response.headers.get('Content-Disposition')
+        if c_d_value:
+            c_d_value = c_d_value.replace('inline', 'attachment')
+        else:
+            c_d_value = 'attachment'
+        if 'filename' not in c_d_value:
+            c_d_value = f'{c_d_value}; filename="{filename}"'
+        response.headers.set('Content-Disposition', c_d_value)
+
+        return response

--- a/ckanext/feedback/controllers/download.py
+++ b/ckanext/feedback/controllers/download.py
@@ -37,7 +37,7 @@ class DownloadController:
             filename=filename,
         )
 
-        if response._status_code == 302:
+        if response.status_code == 302:
             url = response.headers.get('Location')
             log.debug(f"download to redirect URL.[{url}]")
             filename = os.path.basename(urlparse(url).path)
@@ -51,7 +51,7 @@ class DownloadController:
             except requests.exceptions.ConnectionError:
                 log.exception(f'Can not connect to external resource. URL[{url}]')
                 return response
-            if external_response._status_code != 200:
+            if external_response.status_code != 200:
                 log.exception(f'Failure to acquire external resource. URL[{url}]')
                 return response
             response = external_response


### PR DESCRIPTION
レスポンスヘッダの`Content-Disposition`に`attachment`を設定する。
外部リソースの場合はクライアントにリダイレクトを返さずにサーバで取得してクライアントに返す。