### PR TITLE
downloadモジュールOFF時にはtemplateで使用するhrefをCKANデフォルトのものを使用する修正 

### DIFF
--- a/ckanext/feedback/templates/package/resource_read.html
+++ b/ckanext/feedback/templates/package/resource_read.html
@@ -18,11 +18,19 @@
         <a class="btn btn-primary resource-url-analytics" href="{{ res.url }}">
           <i class="fa fa-key"></i> {{ _('API Endpoint') }}
         {% elif not res.has_views and not res.url_type == 'upload' %}
-        <a class="btn btn-primary resource-url-analytics" href="{{ h.url_for('download.download', id=pkg.id, resource_id=res.id) }}">
-          <i class="fa fa-external-link"></i> {{ _('Go to resource') }}
+          {% if h.is_enabled_downloads() %}
+          <a class="btn btn-primary resource-url-analytics" href="{{ h.url_for('download.download', id=pkg.id, resource_id=res.id) }}">
+          {% else %}
+          <a class="btn btn-primary resource-url-analytics" href="{{ res.url }}">
+          {% endif %}
+            <i class="fa fa-external-link"></i> {{ _('Go to resource') }}
         {% else %}
-        <a class="btn btn-primary resource-url-analytics" href="{{ h.url_for('download.download', id=pkg.id, resource_id=res.id) }}?user-download=true" titel="{{ res.url }}" download>
-          <i class="fa fa-arrow-circle-down"></i> {{ _('Download') }}
+          {% if h.is_enabled_downloads() %}
+          <a class="btn btn-primary resource-url-analytics" href="{{ h.url_for('download.download', id=pkg.id, resource_id=res.id) }}?user-download=true" titel="{{ res.url }}" download>
+          {% else %}
+          <a class="btn btn-primary resource-url-analytics" href="{{ res.url }}">
+          {% endif %}
+            <i class="fa fa-arrow-circle-down"></i> {{ _('Download') }}
         {% endif %}
         </a>
       {% endif %}
@@ -85,7 +93,14 @@
 
 {% block resource_read_url %}
   {% if res.url and h.is_url(res.url) %}
-    <p class="text-muted ellipsis">{{ _('URL:') }} <a class="resource-url-analytics" href="{{ h.url_for('download.download', id=pkg.id, resource_id=res.id) }}" title="{{ res.url }}">{{ res.url }}</a></p>
+    <p class="text-muted ellipsis">
+      {{ _('URL:') }}
+      {% if h.is_enabled_downloads() %}
+      <a class="resource-url-analytics" href="{{ h.url_for('download.download', id=pkg.id, resource_id=res.id) }}" title="{{ res.url }}">{{ res.url }}</a>
+      {% else %}
+      <a class="resource-url-analytics" href="{{ res.url }}" title="{{ res.url }}">{{ res.url }}</a>
+      {% endif %}
+    </p>
   {% elif res.url %}
     <p class="text-muted break-word">{{ _('URL:') }} {{ res.url }}</p>
   {% endif %}

--- a/ckanext/feedback/templates/package/snippets/resource_item.html
+++ b/ckanext/feedback/templates/package/snippets/resource_item.html
@@ -91,7 +91,7 @@
               {% if res.has_views or res.url_type == 'upload' %}
               {% if h.is_enabled_downloads() %}
               <a class="dropdown-item resource-url-analytics" href="{{ h.url_for('download.download', id=pkg.id, resource_id=res.id) }}?user-download=true" target="_blank" rel="noreferrer" download>
-        			{% else %}
+              {% else %}
               <a class="dropdown-item resource-url-analytics" href="{{ res.url }}" target="_blank" rel="noreferrer">
               {% endif %}
                 <i class="fa fa-arrow-circle-down"></i>

--- a/ckanext/feedback/templates/package/snippets/resource_item.html
+++ b/ckanext/feedback/templates/package/snippets/resource_item.html
@@ -89,7 +89,11 @@
           {% if res.url and h.is_url(res.url) %}
             <li>
               {% if res.has_views or res.url_type == 'upload' %}
+              {% if h.is_enabled_downloads() %}
               <a class="dropdown-item resource-url-analytics" href="{{ h.url_for('download.download', id=pkg.id, resource_id=res.id) }}?user-download=true" target="_blank" rel="noreferrer" download>
+        			{% else %}
+              <a class="dropdown-item resource-url-analytics" href="{{ res.url }}" target="_blank" rel="noreferrer">
+              {% endif %}
                 <i class="fa fa-arrow-circle-down"></i>
                 {{ _('Download') }}
               {% else %}


### PR DESCRIPTION
## 不具合事象
ckan.iniやfeedback_config.josnにてdownloadモジュールを無効化していた場合に、ダウンロードリンクが存在する画面を表示しようとするとエラー画面が発生。

## 原因
feedbackのDownload用のエンドポイントは、テンプレート内で`h.url_for('download.download', id=pkg.id, resource_id=res.id)` によって取得、設定している。
https://github.com/c-3lab/ckanext-feedback/blob/a8dee2bc58e5033b7667e0f1efdb263855fcaeec/ckanext/feedback/views/download.py#L25-L29

https://github.com/c-3lab/ckanext-feedback/blob/a8dee2bc58e5033b7667e0f1efdb263855fcaeec/ckanext/feedback/templates/package/resource_read.html#L24-L25

しかし、上記のBlueprintの登録は、Downloadモジュールが有効化されていないと行われない。
https://github.com/c-3lab/ckanext-feedback/blob/a8dee2bc58e5033b7667e0f1efdb263855fcaeec/ckanext/feedback/plugin.py#L170-L171

## 対応方法
テンプレート上でdownloadモジュールの有効化状況に応じて処理を分岐する。