### PR TITLE
画面遷移時に言語設定が日本語から英語になってしまう不具合の修正

### DIFF
--- a/ckanext/feedback/controllers/management.py
+++ b/ckanext/feedback/controllers/management.py
@@ -1,7 +1,6 @@
 from ckan.common import _, current_user, g, request
 from ckan.lib import helpers
 from ckan.plugins import toolkit
-from flask import redirect, url_for
 
 import ckanext.feedback.services.management.comments as comments_service
 import ckanext.feedback.services.resource.comment as resource_comment_service
@@ -67,7 +66,7 @@ class ManagementController:
                 f'{len(comments)} ' + _('bulk approval completed.'),
                 allow_html=True,
             )
-        return redirect(url_for('management.comments', tab='utilization-comments'))
+        return toolkit.redirect_to('management.comments', tab='utilization-comments')
 
     # management/approve_bulk_resource_comments
     @staticmethod
@@ -88,7 +87,7 @@ class ManagementController:
                 f'{len(comments)} ' + _('bulk approval completed.'),
                 allow_html=True,
             )
-        return redirect(url_for('management.comments', tab='resource-comments'))
+        return toolkit.redirect_to('management.comments', tab='resource-comments')
 
     # management/delete_bulk_utilization_comments
     @staticmethod
@@ -108,7 +107,7 @@ class ManagementController:
                 f'{len(comments)} ' + _('bulk delete completed.'),
                 allow_html=True,
             )
-        return redirect(url_for('management.comments', tab='utilization-comments'))
+        return toolkit.redirect_to('management.comments', tab='utilization-comments')
 
     # management/delete_bulk_resource_comments
     @staticmethod
@@ -130,7 +129,7 @@ class ManagementController:
                 f'{len(comments)} ' + _('bulk delete completed.'),
                 allow_html=True,
             )
-        return redirect(url_for('management.comments', tab='resource-comments'))
+        return toolkit.redirect_to('management.comments', tab='resource-comments')
 
     @staticmethod
     def _check_organization_admin_role_with_utilization(utilizations):

--- a/ckanext/feedback/controllers/resource.py
+++ b/ckanext/feedback/controllers/resource.py
@@ -5,7 +5,7 @@ from ckan.common import _, config, current_user, g, request
 from ckan.lib import helpers
 from ckan.logic import get_action
 from ckan.plugins import toolkit
-from flask import make_response, redirect, url_for
+from flask import make_response
 
 import ckanext.feedback.services.resource.comment as comment_service
 import ckanext.feedback.services.resource.summary as summary_service
@@ -113,7 +113,7 @@ class ResourceController:
                 target_name=resource.Resource.name,
                 category=category,
                 content=content,
-                url=url_for(
+                url=toolkit.url_for(
                     'resource_comment.comment', resource_id=resource_id, _external=True
                 ),
             )
@@ -129,7 +129,9 @@ class ResourceController:
         )
 
         resp = make_response(
-            redirect(url_for('resource.read', id=package_name, resource_id=resource_id))
+            toolkit.redirect_to(
+                'resource.read', id=package_name, resource_id=resource_id
+            )
         )
 
         resp.set_cookie(resource_id, 'alreadyPosted')
@@ -149,7 +151,7 @@ class ResourceController:
         summary_service.refresh_resource_summary(resource_id)
         session.commit()
 
-        return redirect(url_for('resource_comment.comment', resource_id=resource_id))
+        return toolkit.redirect_to('resource_comment.comment', resource_id=resource_id)
 
     # resource_comment/<resource_id>/comment/reply
     @staticmethod
@@ -164,7 +166,7 @@ class ResourceController:
         comment_service.create_reply(resource_comment_id, content, current_user.id)
         session.commit()
 
-        return redirect(url_for('resource_comment.comment', resource_id=resource_id))
+        return toolkit.redirect_to('resource_comment.comment', resource_id=resource_id)
 
     @staticmethod
     def _check_organization_admin_role(resource_id):

--- a/ckanext/feedback/controllers/utilization.py
+++ b/ckanext/feedback/controllers/utilization.py
@@ -5,7 +5,6 @@ from ckan.common import _, config, current_user, g, request
 from ckan.lib import helpers
 from ckan.logic import get_action
 from ckan.plugins import toolkit
-from flask import redirect, url_for
 
 import ckanext.feedback.services.resource.comment as comment_service
 import ckanext.feedback.services.utilization.details as detail_service
@@ -185,7 +184,7 @@ class UtilizationController:
                 target_name=resource.name,
                 content_title=title,
                 content=description,
-                url=url_for(
+                url=toolkit.url_for(
                     'utilization.details', utilization_id=utilization_id, _external=True
                 ),
             )
@@ -201,11 +200,11 @@ class UtilizationController:
         )
 
         if return_to_resource:
-            return redirect(
-                url_for('resource.read', id=package_name, resource_id=resource_id)
+            return toolkit.redirect_to(
+                'resource.read', id=package_name, resource_id=resource_id
             )
         else:
-            return redirect(url_for('dataset.read', id=package_name))
+            return toolkit.redirect_to('dataset.read', id=package_name)
 
     # utilization/<utilization_id>
     @staticmethod
@@ -265,7 +264,7 @@ class UtilizationController:
         summary_service.refresh_utilization_summary(resource_id)
         session.commit()
 
-        return redirect(url_for('utilization.details', utilization_id=utilization_id))
+        return toolkit.redirect_to('utilization.details', utilization_id=utilization_id)
 
     # utilization/<utilization_id>/comment/new
     @staticmethod
@@ -334,7 +333,7 @@ class UtilizationController:
         detail_service.refresh_utilization_comments(utilization_id)
         session.commit()
 
-        return redirect(url_for('utilization.details', utilization_id=utilization_id))
+        return toolkit.redirect_to('utilization.details', utilization_id=utilization_id)
 
     # utilization/<utilization_id>/edit
     @staticmethod
@@ -406,7 +405,7 @@ class UtilizationController:
             allow_html=True,
         )
 
-        return redirect(url_for('utilization.details', utilization_id=utilization_id))
+        return toolkit.redirect_to('utilization.details', utilization_id=utilization_id)
 
     # utilization/<utilization_id>/delete
     @staticmethod
@@ -424,7 +423,7 @@ class UtilizationController:
             allow_html=True,
         )
 
-        return redirect(url_for('utilization.search'))
+        return toolkit.redirect_to('utilization.search')
 
     # utilization/<utilization_id>/issue_resolution/new
     @staticmethod
@@ -441,7 +440,7 @@ class UtilizationController:
         summary_service.increment_issue_resolution_summary(utilization_id)
         session.commit()
 
-        return redirect(url_for('utilization.details', utilization_id=utilization_id))
+        return toolkit.redirect_to('utilization.details', utilization_id=utilization_id)
 
     @staticmethod
     def _check_organization_admin_role(utilization_id):

--- a/ckanext/feedback/templates/management/comments.html
+++ b/ckanext/feedback/templates/management/comments.html
@@ -85,7 +85,7 @@
                         {{ h.get_organization(row.utilization.resource.package.owner_org).display_name|truncate(20) }}
                       </td>
                       <td>
-                        <a href="{{ url_for('dataset.search') }}{{ row.utilization.resource.package.name }}">{{ row.utilization.resource.package.title|truncate(20) }}</a>
+                        <a href="{{ h.url_for('dataset.search') }}{{ row.utilization.resource.package.name }}">{{ row.utilization.resource.package.title|truncate(20) }}</a>
                       </td>
                       <td>
                         <a href="{{ h.url_for('dataset.search') }}{{ row.utilization.resource.package.name }}/resource/{{ row.utilization.resource.id }}">{{ row.utilization.resource.name|truncate(20) }}</a>
@@ -149,7 +149,7 @@
                         {{ h.get_organization(row.resource.package.owner_org).display_name|truncate(20) }}
                       </td>
                       <td>
-                        <a href="{{ url_for('dataset.search') }}{{ row.resource.package.name }}">{{ row.resource.package.title|truncate(20) }}</a>
+                        <a href="{{h.url_for('dataset.search') }}{{ row.resource.package.name }}">{{ row.resource.package.title|truncate(20) }}</a>
                       </td>
                       <td>
                         <a href="{{ h.url_for('dataset.search') }}{{ row.resource.package.name }}/resource/{{ row.resource.id }}">{{ row.resource.name|truncate(20) }}</a>

--- a/ckanext/feedback/templates/resource/comment.html
+++ b/ckanext/feedback/templates/resource/comment.html
@@ -99,7 +99,7 @@
                   <input type="button" class="btn btn-primary float-end" value="{{ _('Reply') }}" disabled/>
                 {% endif %}
               {% else %}
-                <form name="approval_form" action="{{ url_for('resource_comment.approve_comment', resource_id=resource.id ) }}" method="post">
+                <form name="approval_form" action="{{h.url_for('resource_comment.approve_comment', resource_id=resource.id ) }}" method="post">
                   {% if h.is_base_public_folder_bs3() %}
                     <button class="btn btn-primary pull-right" id="resource_comment_id" name="resource_comment_id" value="{{ comment.id }}" onclick="setButtonDisable(this);">{{ _('Approve') }}</button>
                   {% else %}
@@ -153,7 +153,7 @@
     <div id="reply-form-window" class="modal fade" tabindex="-1">
       <div class="modal-dialog">
         <div class="modal-content">
-          <form id="reply-form" class="top-centered-content" action="{{ url_for('resource_comment.reply', resource_id=resource.id ) }}" method="post">
+          <form id="reply-form" class="top-centered-content" action="{{h.url_for('resource_comment.reply', resource_id=resource.id ) }}" method="post">
             <input type="hidden" id="selected_resource_comment_id" name="resource_comment_id">
             <div class="modal-header">
               {% if h.is_base_public_folder_bs3() %}

--- a/ckanext/feedback/templates/utilization/details.html
+++ b/ckanext/feedback/templates/utilization/details.html
@@ -20,7 +20,7 @@
         {% set row = utilization %}
         <div class="centered-content">
           {% if c.userobj.sysadmin or h.has_organization_admin_role(utilization.owner_org) %}
-            <form name="admin_form" action="{{ url_for('utilization.approve', utilization_id=utilization_id ) }}" method="post">
+            <form name="admin_form" action="{{h.url_for('utilization.approve', utilization_id=utilization_id ) }}" method="post">
               <a class="btn btn-primary right-aligned spaced-left" href="{{ h.url_for('utilization.edit', utilization_id=utilization_id) }}">{{ _('Edit') }}</a>
               {% if row.approval == false %}
                 <button class="btn btn-primary right-aligned" onclick="setButtonDisable(this);">{{ _('Approve') }}</button>
@@ -98,7 +98,7 @@
           {% endif %}
           {% for comment in page.collection %}
             {% if (c.userobj.sysadmin or h.has_organization_admin_role(utilization.owner_org)) and comment.approval == false %}
-              <form name="approval_form" action="{{ url_for('utilization.approve_comment', utilization_id=utilization_id, comment_id=comment.id) }}" method="post">
+              <form name="approval_form" action="{{h.url_for('utilization.approve_comment', utilization_id=utilization_id, comment_id=comment.id) }}" method="post">
                 <button class="btn btn-primary right-aligned" onclick="setButtonDisable(this);">{{ _('Approve') }}</button>
               </form>
             {% endif %}
@@ -124,7 +124,7 @@
     <div id="issue-resolution-form" class="modal fade" tabindex="-1">
       <div class="modal-dialog">
         <div class="modal-content">
-          <form name="issue_resolution_form" class="top-centered-content" action="{{ url_for('utilization.create_issue_resolution', utilization_id=utilization_id ) }}" method="post">
+          <form name="issue_resolution_form" class="top-centered-content" action="{{h.url_for('utilization.create_issue_resolution', utilization_id=utilization_id ) }}" method="post">
             <div class="modal-header">
               {% if h.is_base_public_folder_bs3() %}
                 <button type="button" class="close" data-dismiss="modal">&times;</button>

--- a/ckanext/feedback/tests/controllers/test_management.py
+++ b/ckanext/feedback/tests/controllers/test_management.py
@@ -156,8 +156,7 @@ class TestManagementController:
 
     @patch('flask_login.utils._get_user')
     @patch('ckanext.feedback.controllers.management._')
-    @patch('ckanext.feedback.controllers.management.redirect')
-    @patch('ckanext.feedback.controllers.management.url_for')
+    @patch('ckanext.feedback.controllers.management.toolkit.redirect_to')
     @patch('ckanext.feedback.controllers.management.helpers.flash_success')
     @patch('ckanext.feedback.controllers.management.session.commit')
     @patch('ckanext.feedback.controllers.management.comments_service')
@@ -168,8 +167,7 @@ class TestManagementController:
         mock_comments_service,
         mock_session_commit,
         mock_flash_success,
-        mock_url_for,
-        mock_redirect,
+        mock_redirect_to,
         _,
         current_user,
         app,
@@ -182,8 +180,7 @@ class TestManagementController:
 
         mock_form.getlist.return_value = comments
         mock_comments_service.get_utilizations.return_value = utilizations
-        mock_url_for.return_value = 'url'
-        mock_redirect.return_value = 'redirect_response'
+        mock_redirect_to.return_value = 'redirect_response'
         user_dict = factories.Sysadmin()
         mock_current_user(current_user, user_dict)
 
@@ -204,23 +201,20 @@ class TestManagementController:
             f'{len(comments)} ' + _('bulk approval completed.'),
             allow_html=True,
         )
-        mock_url_for.assert_called_once_with(
+        mock_redirect_to.assert_called_once_with(
             'management.comments', tab='utilization-comments'
         )
-        mock_redirect.assert_called_once_with('url')
 
         assert response == 'redirect_response'
 
     @patch('flask_login.utils._get_user')
-    @patch('ckanext.feedback.controllers.management.redirect')
-    @patch('ckanext.feedback.controllers.management.url_for')
+    @patch('ckanext.feedback.controllers.management.toolkit.redirect_to')
     @patch('ckanext.feedback.controllers.management.request.form')
     def test_approve_bulk_utilization_comments_without_comment(
-        self, mock_form, mock_url_for, mock_redirect, current_user, app, sysadmin_env
+        self, mock_form, mock_redirect_to, current_user, app, sysadmin_env
     ):
         mock_form.getlist.return_value = None
-        mock_url_for.return_value = 'url'
-        mock_redirect.return_value = 'redirect_response'
+        mock_redirect_to.return_value = 'redirect_response'
         user_dict = factories.Sysadmin()
         mock_current_user(current_user, user_dict)
 
@@ -228,14 +222,11 @@ class TestManagementController:
             g.userobj = current_user
             response = ManagementController.approve_bulk_utilization_comments()
 
-        mock_redirect.assert_called_once_with('url')
-
         assert response == 'redirect_response'
 
     @patch('flask_login.utils._get_user')
     @patch('ckanext.feedback.controllers.management._')
-    @patch('ckanext.feedback.controllers.management.redirect')
-    @patch('ckanext.feedback.controllers.management.url_for')
+    @patch('ckanext.feedback.controllers.management.toolkit.redirect_to')
     @patch('ckanext.feedback.controllers.management.helpers.flash_success')
     @patch('ckanext.feedback.controllers.management.session.commit')
     @patch('ckanext.feedback.controllers.management.comments_service')
@@ -246,8 +237,7 @@ class TestManagementController:
         mock_comments_service,
         mock_session_commit,
         mock_flash_success,
-        mock_url_for,
-        mock_redirect,
+        mock_redirect_to,
         _,
         current_user,
         app,
@@ -262,8 +252,7 @@ class TestManagementController:
         mock_comments_service.get_resource_comment_summaries.return_value = (
             resource_comment_summaries
         )
-        mock_url_for.return_value = 'url'
-        mock_redirect.return_value = 'redirect_response'
+        mock_redirect_to.return_value = 'redirect_response'
         user_dict = factories.Sysadmin()
         mock_current_user(current_user, user_dict)
 
@@ -286,29 +275,25 @@ class TestManagementController:
             f'{len(comments)} ' + _('bulk approval completed.'),
             allow_html=True,
         )
-        mock_url_for.assert_called_once_with(
+        mock_redirect_to.assert_called_once_with(
             'management.comments', tab='resource-comments'
         )
-        mock_redirect.assert_called_once_with('url')
 
         assert response == 'redirect_response'
 
     @patch('flask_login.utils._get_user')
-    @patch('ckanext.feedback.controllers.management.redirect')
-    @patch('ckanext.feedback.controllers.management.url_for')
+    @patch('ckanext.feedback.controllers.management.toolkit.redirect_to')
     @patch('ckanext.feedback.controllers.management.request.form')
     def test_approve_bulk_resource_comments_without_comment(
         self,
         mock_form,
-        mock_url_for,
-        mock_redirect,
+        mock_redirect_to,
         current_user,
         app,
         sysadmin_env,
     ):
         mock_form.getlist.return_value = None
-        mock_url_for.return_value = 'url'
-        mock_redirect.return_value = 'redirect_response'
+        mock_redirect_to.return_value = 'redirect_response'
         user_dict = factories.Sysadmin()
         mock_current_user(current_user, user_dict)
 
@@ -316,17 +301,15 @@ class TestManagementController:
             g.userobj = current_user
             response = ManagementController.approve_bulk_resource_comments()
 
-        mock_url_for.assert_called_once_with(
+        mock_redirect_to.assert_called_once_with(
             'management.comments', tab='resource-comments'
         )
-        mock_redirect.assert_called_once_with('url')
 
         assert response == 'redirect_response'
 
     @patch('flask_login.utils._get_user')
     @patch('ckanext.feedback.controllers.management._')
-    @patch('ckanext.feedback.controllers.management.redirect')
-    @patch('ckanext.feedback.controllers.management.url_for')
+    @patch('ckanext.feedback.controllers.management.toolkit.redirect_to')
     @patch('ckanext.feedback.controllers.management.helpers.flash_success')
     @patch('ckanext.feedback.controllers.management.session.commit')
     @patch('ckanext.feedback.controllers.management.comments_service')
@@ -337,8 +320,7 @@ class TestManagementController:
         mock_comments_service,
         mock_session_commit,
         mock_flash_success,
-        mock_url_for,
-        mock_redirect,
+        mock_redirect_to,
         _,
         current_user,
         app,
@@ -351,8 +333,7 @@ class TestManagementController:
 
         mock_form.getlist.return_value = comments
         mock_comments_service.get_utilizations.return_value = utilizations
-        mock_url_for.return_value = 'url'
-        mock_redirect.return_value = 'redirect_response'
+        mock_redirect_to.return_value = 'redirect_response'
         user_dict = factories.Sysadmin()
         mock_current_user(current_user, user_dict)
 
@@ -373,29 +354,25 @@ class TestManagementController:
             f'{len(comments)} ' + _('bulk delete completed.'),
             allow_html=True,
         )
-        mock_url_for.assert_called_once_with(
+        mock_redirect_to.assert_called_once_with(
             'management.comments', tab='utilization-comments'
         )
-        mock_redirect.assert_called_once_with('url')
 
         assert response == 'redirect_response'
 
     @patch('flask_login.utils._get_user')
-    @patch('ckanext.feedback.controllers.management.redirect')
-    @patch('ckanext.feedback.controllers.management.url_for')
+    @patch('ckanext.feedback.controllers.management.toolkit.redirect_to')
     @patch('ckanext.feedback.controllers.management.request.form')
     def test_delete_bulk_utilization_comments_without_comment(
         self,
         mock_form,
-        mock_url_for,
-        mock_redirect,
+        mock_redirect_to,
         current_user,
         app,
         sysadmin_env,
     ):
         mock_form.getlist.return_value = None
-        mock_url_for.return_value = 'url'
-        mock_redirect.return_value = 'redirect_response'
+        mock_redirect_to.return_value = 'redirect_response'
         user_dict = factories.Sysadmin()
         mock_current_user(current_user, user_dict)
 
@@ -403,17 +380,15 @@ class TestManagementController:
             g.userobj = current_user
             response = ManagementController.delete_bulk_utilization_comments()
 
-        mock_url_for.assert_called_once_with(
+        mock_redirect_to.assert_called_once_with(
             'management.comments', tab='utilization-comments'
         )
-        mock_redirect.assert_called_once_with('url')
 
         assert response == 'redirect_response'
 
     @patch('flask_login.utils._get_user')
     @patch('ckanext.feedback.controllers.management._')
-    @patch('ckanext.feedback.controllers.management.redirect')
-    @patch('ckanext.feedback.controllers.management.url_for')
+    @patch('ckanext.feedback.controllers.management.toolkit.redirect_to')
     @patch('ckanext.feedback.controllers.management.helpers.flash_success')
     @patch('ckanext.feedback.controllers.management.session.commit')
     @patch('ckanext.feedback.controllers.management.comments_service')
@@ -424,8 +399,7 @@ class TestManagementController:
         mock_comments_service,
         mock_session_commit,
         mock_flash_success,
-        mock_url_for,
-        mock_redirect,
+        mock_redirect_to,
         _,
         current_user,
         app,
@@ -445,8 +419,7 @@ class TestManagementController:
         mock_comments_service.get_resource_comment_summaries.return_value = (
             resource_comment_summaries
         )
-        mock_url_for.return_value = 'url'
-        mock_redirect.return_value = 'redirect_response'
+        mock_redirect_to.return_value = 'redirect_response'
         user_dict = factories.Sysadmin()
         mock_current_user(current_user, user_dict)
 
@@ -467,29 +440,25 @@ class TestManagementController:
             f'{len(comments)} ' + _('bulk delete completed.'),
             allow_html=True,
         )
-        mock_url_for.assert_called_once_with(
+        mock_redirect_to.assert_called_once_with(
             'management.comments', tab='resource-comments'
         )
-        mock_redirect.assert_called_once_with('url')
 
         assert response == 'redirect_response'
 
     @patch('flask_login.utils._get_user')
-    @patch('ckanext.feedback.controllers.management.redirect')
-    @patch('ckanext.feedback.controllers.management.url_for')
+    @patch('ckanext.feedback.controllers.management.toolkit.redirect_to')
     @patch('ckanext.feedback.controllers.management.request.form')
     def test_delete_bulk_resource_comments_without_comment(
         self,
         mock_form,
-        mock_url_for,
-        mock_redirect,
+        mock_redirect_to,
         current_user,
         app,
         sysadmin_env,
     ):
         mock_form.getlist.return_value = None
-        mock_url_for.return_value = 'url'
-        mock_redirect.return_value = 'redirect_response'
+        mock_redirect_to.return_value = 'redirect_response'
         user_dict = factories.Sysadmin()
         mock_current_user(current_user, user_dict)
 
@@ -497,10 +466,9 @@ class TestManagementController:
             g.userobj = current_user
             response = ManagementController.delete_bulk_resource_comments()
 
-        mock_url_for.assert_called_once_with(
+        mock_redirect_to.assert_called_once_with(
             'management.comments', tab='resource-comments'
         )
-        mock_redirect.assert_called_once_with('url')
 
         assert response == 'redirect_response'
 

--- a/ckanext/feedback/tests/controllers/test_utilization.py
+++ b/ckanext/feedback/tests/controllers/test_utilization.py
@@ -697,12 +697,10 @@ class TestUtilizationController:
     @patch('ckanext.feedback.controllers.utilization.summary_service')
     @patch('ckanext.feedback.controllers.utilization.session.commit')
     @patch('ckanext.feedback.controllers.utilization.helpers.flash_success')
-    @patch('ckanext.feedback.controllers.utilization.url_for')
-    @patch('ckanext.feedback.controllers.utilization.redirect')
+    @patch('ckanext.feedback.controllers.utilization.toolkit.redirect_to')
     def test_create_return_to_resource_true(
         self,
-        mock_redirect,
-        mock_url_for,
+        mock_redirect_to,
         mock_flash_success,
         mock_session_commit,
         mock_summary_service,
@@ -724,7 +722,6 @@ class TestUtilizationController:
             description,
             return_to_resource,
         ]
-        mock_url_for.return_value = 'resource read url'
 
         UtilizationController.create()
 
@@ -734,22 +731,19 @@ class TestUtilizationController:
         mock_summary_service.create_utilization_summary.assert_called_with(resource_id)
         mock_session_commit.assert_called_once()
         mock_flash_success.assert_called_once()
-        mock_url_for.assert_called_once_with(
+        mock_redirect_to.assert_called_once_with(
             'resource.read', id=package_name, resource_id=resource_id
         )
-        mock_redirect.assert_called_with('resource read url')
 
     @patch('ckanext.feedback.controllers.utilization.request.form')
     @patch('ckanext.feedback.controllers.utilization.registration_service')
     @patch('ckanext.feedback.controllers.utilization.summary_service')
     @patch('ckanext.feedback.controllers.utilization.session.commit')
     @patch('ckanext.feedback.controllers.utilization.helpers.flash_success')
-    @patch('ckanext.feedback.controllers.utilization.url_for')
-    @patch('ckanext.feedback.controllers.utilization.redirect')
+    @patch('ckanext.feedback.controllers.utilization.toolkit.redirect_to')
     def test_create_return_to_resource_false(
         self,
-        mock_redirect,
-        mock_url_for,
+        mock_redirect_to,
         mock_flash_success,
         mock_session_commit,
         mock_summary_service,
@@ -771,7 +765,6 @@ class TestUtilizationController:
             description,
             return_to_resource,
         ]
-        mock_url_for.return_value = 'dataset read url'
 
         UtilizationController.create()
 
@@ -781,18 +774,15 @@ class TestUtilizationController:
         mock_summary_service.create_utilization_summary.assert_called_with(resource_id)
         mock_session_commit.assert_called_once()
         mock_flash_success.assert_called_once()
-        mock_url_for.assert_called_once_with('dataset.read', id=package_name)
-        mock_redirect.assert_called_with('dataset read url')
+        mock_redirect_to.assert_called_once_with('dataset.read', id=package_name)
 
     @patch('ckanext.feedback.controllers.utilization.toolkit.abort')
     @patch('ckanext.feedback.controllers.utilization.request.form')
     @patch('ckanext.feedback.controllers.utilization.registration_service')
     @patch('ckanext.feedback.controllers.utilization.summary_service')
     @patch('ckanext.feedback.controllers.utilization.helpers.flash_success')
-    @patch('ckanext.feedback.controllers.utilization.url_for')
     def test_create_without_resource_id_title_description(
         self,
-        mock_url_for,
         mock_flash_success,
         mock_summary_service,
         mock_registration_service,
@@ -814,7 +804,6 @@ class TestUtilizationController:
             description,
             return_to_resource,
         ]
-        mock_url_for.return_value = 'resource read url'
 
         UtilizationController.create()
 
@@ -1339,12 +1328,10 @@ class TestUtilizationController:
     @patch('ckanext.feedback.controllers.utilization.detail_service')
     @patch('ckanext.feedback.controllers.utilization.summary_service')
     @patch('ckanext.feedback.controllers.utilization.session.commit')
-    @patch('ckanext.feedback.controllers.utilization.url_for')
-    @patch('ckanext.feedback.controllers.utilization.redirect')
+    @patch('ckanext.feedback.controllers.utilization.toolkit.redirect_to')
     def test_approve(
         self,
-        mock_redirect,
-        mock_url_for,
+        mock_redirect_to,
         mock_session_commit,
         mock_summary_service,
         mock_detail_service,
@@ -1359,7 +1346,6 @@ class TestUtilizationController:
         mock_detail_service.get_utilization.return_value = MagicMock(
             resource_id=resource_id
         )
-        mock_url_for.return_value = 'utilization details url'
 
         UtilizationController.approve(utilization_id)
 
@@ -1371,10 +1357,9 @@ class TestUtilizationController:
             resource_id
         )
         mock_session_commit.assert_called_once()
-        mock_url_for.assert_called_once_with(
+        mock_redirect_to.assert_called_once_with(
             'utilization.details', utilization_id=utilization_id
         )
-        mock_redirect.assert_called_once_with('utilization details url')
 
     @patch('ckanext.feedback.controllers.utilization.request.form')
     @patch('ckanext.feedback.controllers.utilization.detail_service')
@@ -1410,10 +1395,8 @@ class TestUtilizationController:
     @patch('ckanext.feedback.controllers.utilization.request.form')
     @patch('ckanext.feedback.controllers.utilization.detail_service')
     @patch('ckanext.feedback.controllers.utilization.helpers.flash_success')
-    @patch('ckanext.feedback.controllers.utilization.url_for')
     def test_create_comment_without_category_content(
         self,
-        mock_url_for,
         mock_flash_success,
         mock_detail_service,
         mock_form,
@@ -1424,7 +1407,6 @@ class TestUtilizationController:
         content = ''
 
         mock_form.get.side_effect = [category, content]
-        mock_url_for.return_value = 'utilization details url'
 
         UtilizationController.create_comment(utilization_id)
 
@@ -1488,12 +1470,10 @@ class TestUtilizationController:
     @patch('flask_login.utils._get_user')
     @patch('ckanext.feedback.controllers.utilization.detail_service')
     @patch('ckanext.feedback.controllers.utilization.session.commit')
-    @patch('ckanext.feedback.controllers.utilization.url_for')
-    @patch('ckanext.feedback.controllers.utilization.redirect')
+    @patch('ckanext.feedback.controllers.utilization.toolkit.redirect_to')
     def test_approve_comment(
         self,
-        mock_redirect,
-        mock_url_for,
+        mock_redirect_to,
         mock_session_commit,
         mock_detail_service,
         current_user,
@@ -1502,8 +1482,6 @@ class TestUtilizationController:
         comment_id = 'comment id'
         user_dict = factories.Sysadmin()
         mock_current_user(current_user, user_dict)
-
-        mock_url_for.return_value = 'utilization details url'
 
         g.userobj = current_user
         UtilizationController.approve_comment(utilization_id, comment_id)
@@ -1515,10 +1493,9 @@ class TestUtilizationController:
             utilization_id
         )
         mock_session_commit.assert_called_once()
-        mock_url_for.assert_called_once_with(
+        mock_redirect_to.assert_called_once_with(
             'utilization.details', utilization_id=utilization_id
         )
-        mock_redirect.assert_called_once_with('utilization details url')
 
     @patch('flask_login.utils._get_user')
     @patch('ckanext.feedback.controllers.utilization.toolkit.render')
@@ -1578,14 +1555,12 @@ class TestUtilizationController:
     @patch('ckanext.feedback.controllers.utilization.edit_service')
     @patch('ckanext.feedback.controllers.utilization.session.commit')
     @patch('ckanext.feedback.controllers.utilization.helpers.flash_success')
-    @patch('ckanext.feedback.controllers.utilization.url_for')
-    @patch('ckanext.feedback.controllers.utilization.redirect')
+    @patch('ckanext.feedback.controllers.utilization.toolkit.redirect_to')
     @patch('ckanext.feedback.controllers.utilization.detail_service')
     def test_update(
         self,
         mock_detail_service,
-        mock_redirect,
-        mock_url_for,
+        mock_redirect_to,
         mock_flash_success,
         mock_session_commit,
         mock_edit_service,
@@ -1598,7 +1573,6 @@ class TestUtilizationController:
         description = 'description'
 
         mock_form.get.side_effect = [title, url, description]
-        mock_url_for.return_value = 'utilization details url'
 
         organization = factories.Organization()
         utilization = MagicMock()
@@ -1614,22 +1588,19 @@ class TestUtilizationController:
         )
         mock_session_commit.assert_called_once()
         mock_flash_success.assert_called_once()
-        mock_url_for.assert_called_once_with(
+        mock_redirect_to.assert_called_once_with(
             'utilization.details', utilization_id=utilization_id
         )
-        mock_redirect.assert_called_once_with('utilization details url')
 
     @patch('flask_login.utils._get_user')
     @patch('ckanext.feedback.controllers.utilization.toolkit.abort')
     @patch('ckanext.feedback.controllers.utilization.request.form')
     @patch('ckanext.feedback.controllers.utilization.edit_service')
     @patch('ckanext.feedback.controllers.utilization.helpers.flash_success')
-    @patch('ckanext.feedback.controllers.utilization.url_for')
     @patch('ckanext.feedback.controllers.utilization.detail_service')
     def test_update_without_title_description(
         self,
         mock_detail_service,
-        mock_url_for,
         mock_flash_success,
         mock_edit_service,
         mock_form,
@@ -1642,7 +1613,6 @@ class TestUtilizationController:
         description = ''
 
         mock_form.get.side_effect = [title, url, description]
-        mock_url_for.return_value = 'utilization_details_url'
 
         organization = factories.Organization()
         utilization = MagicMock()
@@ -1782,12 +1752,10 @@ class TestUtilizationController:
     @patch('ckanext.feedback.controllers.utilization.summary_service')
     @patch('ckanext.feedback.controllers.utilization.session.commit')
     @patch('ckanext.feedback.controllers.utilization.helpers.flash_success')
-    @patch('ckanext.feedback.controllers.utilization.url_for')
-    @patch('ckanext.feedback.controllers.utilization.redirect')
+    @patch('ckanext.feedback.controllers.utilization.toolkit.redirect_to')
     def test_delete(
         self,
-        mock_redirect,
-        mock_url_for,
+        mock_redirect_to,
         mock_flash_success,
         mock_session_commit,
         mock_summary_service,
@@ -1802,8 +1770,6 @@ class TestUtilizationController:
         utilization.resource_id = resource_id
         mock_detail_service.get_utilization.return_value = utilization
 
-        mock_url_for.return_value = 'utilization search url'
-
         user_dict = factories.Sysadmin()
         mock_current_user(current_user, user_dict)
         g.userobj = current_user
@@ -1816,20 +1782,17 @@ class TestUtilizationController:
         )
         assert mock_session_commit.call_count == 2
         mock_flash_success.assert_called_once()
-        mock_url_for.assert_called_once_with('utilization.search')
-        mock_redirect.assert_called_once_with('utilization search url')
+        mock_redirect_to.assert_called_once_with('utilization.search')
 
     @patch('flask_login.utils._get_user')
     @patch('ckanext.feedback.controllers.utilization.request.form')
     @patch('ckanext.feedback.controllers.utilization.detail_service')
     @patch('ckanext.feedback.controllers.utilization.summary_service')
     @patch('ckanext.feedback.controllers.utilization.session.commit')
-    @patch('ckanext.feedback.controllers.utilization.url_for')
-    @patch('ckanext.feedback.controllers.utilization.redirect')
+    @patch('ckanext.feedback.controllers.utilization.toolkit.redirect_to')
     def test_create_issue_resolution(
         self,
-        mock_redirect,
-        mock_url_for,
+        mock_redirect_to,
         mock_session_commit,
         mock_summary_service,
         mock_detail_service,
@@ -1840,7 +1803,6 @@ class TestUtilizationController:
         description = 'description'
 
         mock_form.get.return_value = description
-        mock_url_for.return_value = 'utilization details url'
 
         user_dict = factories.Sysadmin()
         mock_current_user(current_user, user_dict)
@@ -1854,20 +1816,19 @@ class TestUtilizationController:
             utilization_id
         )
         mock_session_commit.assert_called_once()
-        mock_url_for.assert_called_once_with(
+        mock_redirect_to.assert_called_once_with(
             'utilization.details', utilization_id=utilization_id
         )
-        mock_redirect.assert_called_once_with('utilization details url')
 
     @patch('flask_login.utils._get_user')
     @patch('ckanext.feedback.controllers.utilization.toolkit.abort')
     @patch('ckanext.feedback.controllers.utilization.request.form')
     @patch('ckanext.feedback.controllers.utilization.detail_service')
     @patch('ckanext.feedback.controllers.utilization.summary_service')
-    @patch('ckanext.feedback.controllers.utilization.url_for')
+    @patch('ckanext.feedback.controllers.utilization.toolkit.redirect_to')
     def test_create_issue_resolution_without_description(
         self,
-        mock_url_for,
+        mock_redirect_to,
         mock_summary_service,
         mock_detail_service,
         mock_form,
@@ -1879,7 +1840,7 @@ class TestUtilizationController:
         description = ''
 
         mock_form.get.return_value = description
-        mock_url_for.return_value = 'utilization details url'
+        mock_redirect_to.return_value = ''
 
         with self.app.test_request_context():
             user_dict = factories.Sysadmin()


### PR DESCRIPTION
flaskによるurlの取得、リダイレクトではなく、ckanのtoolkitを使用するように修正。