### PR TITLE
リソース説明文の表示バグ修正

### DIFF
--- a/ckanext/feedback/assets/css/tooltip.css
+++ b/ckanext/feedback/assets/css/tooltip.css
@@ -10,7 +10,7 @@
     width: 15px;
     height: 15px
 }
-.description {
+.bubbleText {
     display: none;
     position: absolute;
     bottom: 100%;  
@@ -22,7 +22,7 @@
     background: #000;
     width: 125px;
 }
-.description:before {
+.bubbleText:before {
     content: "";
     position: absolute;
     top: 100%;
@@ -31,7 +31,7 @@
     border-top: 5px solid #000;
     margin-left: -15px;
 }
-.bubble:hover .description{
+.bubble:hover .bubbleText{
     display: inline-block;
     top: -25px;
     left: -40px;

--- a/ckanext/feedback/templates/package/snippets/resource_item.html
+++ b/ckanext/feedback/templates/package/snippets/resource_item.html
@@ -6,13 +6,19 @@
     {{ h.resource_display_name(res) | truncate(50) }}<span class="format-label" property="dc:format" data-format="{{ res.format.lower() or 'data' }}">{{ h.get_translated(res, 'format') }}</span>
     {{ h.popular('views', res.tracking_summary.total, min=10) if res.tracking_summary }}
   </a>
-	<br>
+{% endblock %}
+{% block resource_item_description %}
+  <p class="description">
+    {% if res.description %}
+      {{ h.markdown_extract(h.get_translated(res, 'description'), extract_length=80) }}
+    {% endif %}
+  </p>
   {% if h.is_enabled_downloads(pkg.owner_org) %}
     <a style="color: inherit; text-decoration: none;" href="{{ h.url_for('resource.read', id=pkg.id, resource_id=res.id, package_type='dataset') }}">
       <div class = "bubble">
         <i class="fa-solid fa-arrow-circle-down" style="vertical-align: middle;"></i>
         {{ h.get_resource_downloads(res.id) }}
-        <div class="description">{{ _('Downloads') }}</div>
+        <div class="bubbleText">{{ _('Downloads') }}</div>
       </div>
     </a>
   {% endif %}
@@ -21,7 +27,7 @@
       <div class="bubble">
         <i class="fa-solid fa-seedling" style="vertical-align: middle;"></i>
         {{ h.get_resource_utilizations(res.id) }}
-        <div class="description">{{ _('Utilizations') }}</div>
+        <div class="bubbleText">{{ _('Utilizations') }}</div>
       </div>
     </a>
   {% endif %}
@@ -30,7 +36,7 @@
       <div class="utilization-data bubble">
         <i class="fa-solid fa-comment-dots" style="vertical-align: middle;"></i>
         {{ h.get_resource_comments(res.id) }}
-        <div class="description">{{ _('Comments') }}</div>
+        <div class="bubbleText">{{ _('Comments') }}</div>
       </div>
     </a>
     {% if h.is_enabled_rating(pkg.owner_org) %}
@@ -38,7 +44,7 @@
         <div class="utilization-data bubble">
           <i class="fa-solid fa-star" style="vertical-align: middle;"></i>
           {{ h.get_resource_rating(res.id)|round(1) }}
-          <div class="description">{{ _('Rating') }}</div>
+          <div class="bubbleText">{{ _('Rating') }}</div>
         </div>
       </a>
     {% endif %}
@@ -48,7 +54,7 @@
       <div class="bubble">
         <img id="issue-resolution" style="vertical-align: middle;" src="/images/issue_resolution_badge.png">
         {{ h.get_resource_issue_resolutions(res.id) }}
-        <div class="description">{{ _('Issue Resolutions') }}</div>
+        <div class="bubbleText">{{ _('Issue Resolutions') }}</div>
       </div>
     </a>
   {% endif %}

--- a/ckanext/feedback/templates/snippets/package_item.html
+++ b/ckanext/feedback/templates/snippets/package_item.html
@@ -18,7 +18,7 @@
       <div class = "bubble">
         <i class="fa-solid fa-arrow-circle-down" style="vertical-align: middle;"></i>
         {{ h.get_package_downloads(package.id) }}
-        <div class="description">{{ _('Downloads') }}</div>
+        <div class="bubbleText">{{ _('Downloads') }}</div>
       </div>
     {% endif %}
   </li>
@@ -27,7 +27,7 @@
       <div class="utilization-data bubble">
         <i class="fa-solid fa-seedling" style="vertical-align: middle;"></i>
         <a href="{{ h.url_for('utilization.search', id=package.id, disable_keyword=true) }}">{{ h.get_package_utilizations(package.id) }}</a>
-        <div class="description">{{ _('Utilizations') }}</div>
+        <div class="bubbleText">{{ _('Utilizations') }}</div>
       </div>
     {% endif %}
   </li>
@@ -37,7 +37,7 @@
         <div class="utilization-data bubble">
           <i class="fa-solid fa-comment-dots" style="vertical-align: middle;"></i>
           {{ h.get_package_comments(package.id) }}
-          <div class="description">{{ _('Comments') }}</div>
+          <div class="bubbleText">{{ _('Comments') }}</div>
         </div>
       </a>
     {% endif %}
@@ -48,7 +48,7 @@
         <div class="utilization-data bubble">
           <i class="fa-solid fa-star" style="vertical-align: middle;"></i>
           {{ h.get_package_rating(package.id)|round(1) }}
-          <div class="description">{{ _('Rating') }}</div>
+          <div class="bubbleText">{{ _('Rating') }}</div>
         </div>
       {% endif %}
     {% endif %}
@@ -58,7 +58,7 @@
       <div class="bubble">
         <img id="issue-resolution" style="vertical-align: middle;" src="/images/issue_resolution_badge.png">
         {{ h.get_package_issue_resolutions(package.id) }}
-        <div class="description">{{ _('Issue Resolutions') }}</div>
+        <div class="bubbleText">{{ _('Issue Resolutions') }}</div>
       </div>
     {% endif %}
   </li>


### PR DESCRIPTION
### 事象
データセットページでリソースの説明文がhtmlソースにはあるが、ブラウザ上で表示されない。

### 原因
リソースの説明文のクラス名とツールチップのテキスト部分のクラス名が重複しており、ツールチップのテキスト部分を非表示にする設定がリソースの説明文にも適応されてしまっている。

### 対応
・ツールチップのテキスト部分のクラス名の変更（`description`　→　`bubbleText`）
・クラス名の変更に伴いcssの修正
・リソースタイトルの下部に説明文が配置されるように修正

<変更前>
<img width="633" alt="{BDF7D4F4-4EE7-4E2A-9362-7A06DBAFC9FF}" src="https://github.com/user-attachments/assets/c9c5c480-bbe1-49ac-9628-2a2325b2e616">

<変更後>
<img width="644" alt="{B75B91CF-FC18-4C0D-B0A1-AAC924B78164}" src="https://github.com/user-attachments/assets/c101151a-26af-4a43-b239-70cf0e975820">

