### PR TITLE
開発環境でのメール通知不具合修正及び、利活用申請関連のメール通知不具合修正

### DIFF
--- a/ckanext/feedback/controllers/utilization.py
+++ b/ckanext/feedback/controllers/utilization.py
@@ -178,9 +178,9 @@ class UtilizationController:
             resource = comment_service.get_resource(resource_id)
             send_email(
                 template_name=FeedbackConfig().notice_email.template_utilization.get(),
-                organization_id=resource.package.owner_org,
+                organization_id=resource.Resource.package.owner_org,
                 subject=FeedbackConfig().notice_email.subject_utilization.get(),
-                target_name=resource.name,
+                target_name=resource.Resource.name,
                 content_title=title,
                 content=description,
                 url=toolkit.url_for(
@@ -299,7 +299,7 @@ class UtilizationController:
                 ),
                 organization_id=comment_service.get_resource(
                     utilization.resource_id
-                ).package.owner_org,
+                ).Resource.package.owner_org,
                 subject=FeedbackConfig().notice_email.subject_utilization_comment.get(),
                 target_name=utilization.title,
                 category=category,

--- a/development/feedback_setup.sh
+++ b/development/feedback_setup.sh
@@ -6,7 +6,13 @@ docker exec -it ckan-docker-ckan-dev-1 bash -c "pip install /srv/app/src_extensi
 docker exec -it ckan-docker-ckan-dev-1 bash -c "sed -i 's/\(ckan\.plugins = .*\)/\1 feedback/' /srv/app/ckan.ini"
 # initialize the database for feedback
 docker exec -it ckan-docker-ckan-dev-1 bash -c "ckan db upgrade -p feedback"
-# Copy ckan.datapusher.api_token setting value from ckan-dev to ckan-worker in ckan.ini
-docker exec ckan-docker-ckan-dev-1 sh -c "grep '^ckan.datapusher.api_token' /srv/app/ckan.ini" | xargs -I {} docker exec ckan-docker-ckan-worker-1 sh -c "sed -i '/^\[app:main\]/a {}' /srv/app/ckan.ini"
+# Copy the ckan.ini file from the ckan-docker-ckan-dev-1 container to the host's /tmp directory
+docker cp ckan-docker-ckan-dev-1:/srv/app/ckan.ini /tmp/ckan.ini
+# Remove the "feedback" plugin from the "ckan.plugins" setting in the copied ckan.ini file
+sed -i '/^ckan.plugins = /s/ feedback//' /tmp/ckan.ini
+# Copy the modified ckan.ini file back to the ckan-docker-ckan-worker-1 container, overwriting the existing one
+docker cp /tmp/ckan.ini ckan-docker-ckan-worker-1:/srv/app/ckan.ini
+# Delete the temporary /tmp/ckan.ini file used for the modification
+rm /tmp/ckan.ini
 # Restart to apply worker settings
 docker restart ckan-docker-ckan-worker-1


### PR DESCRIPTION
**開発環境でのメール通知不具合**

・事象
開発環境でfeedbackをインストールしたCKAN環境を構築した際に、メール通知に利用するコンテナ(ckan-worker)が正常に起動しない。
それにより、メール通知機能が動作せず、想定していたメールが届かない。

・原因
シェルには、ローカルckan Webサーバーであるckan-devコンテナから、ckanジョブ実行用であるckan-workerコンテナに、ckan.iniの一部をコピーして追記する処理がある。
ローカルで作業中にckan-workerのckan.iniにすでに記述済みになっている場合、このシェルを実行してckan-workerを起動させても、重複する記述が見つかり起動失敗となる。

・対応
構築手順で利用するシェル(feedback_setup.sh)を修正することで、コンテナ(ckan-worker)が正常に動作し、メールが送信された。

**利活用申請関連のメール通知不具合**

・事象
利活用申請、利活用コメントをした際に、メール通知機能で送信されるはずのメールが届かない。

・原因
メール送信の関数(send_email)に渡す引数が誤っており、引数オブジェクトの属性参照が適切ではなかった。

・対応
引数オブジェクトの属性参照を正しいものに修正し、メールが送信された。
