### PR TITLE
メール通知 テンプレートのデフォルトディレクトリ修正

### DIFF
--- a/ckanext/feedback/services/common/config.py
+++ b/ckanext/feedback/services/common/config.py
@@ -306,7 +306,8 @@ class NoticeEmailConfig(BaseConfig, FeedbackConfigInterface):
 
         parents = self.conf_path
         self.template_directory = BaseConfig('template_directory', parents)
-        # /xxx/xxx/xxxxx/xxxxx/ckanext/feedback/templates/email_notification
+        # e.g., /usr/lib/python3.10/site-packages
+        # /ckanext/feedback/templates/email_notification
         email_template_dir = os.path.abspath(
             os.path.join(
                 os.path.dirname(__file__), '..', '..', 'templates', 'email_notification'

--- a/ckanext/feedback/services/common/config.py
+++ b/ckanext/feedback/services/common/config.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 from abc import ABC, abstractmethod
 
 from ckan.common import config
@@ -305,11 +306,13 @@ class NoticeEmailConfig(BaseConfig, FeedbackConfigInterface):
 
         parents = self.conf_path
         self.template_directory = BaseConfig('template_directory', parents)
-        self.template_directory.default = (
-            '/srv/app/src_extensions/ckanext-feedback/'
-            'ckanext/feedback/templates/email_notificatio'
+        # /xxx/xxx/xxxxx/xxxxx/ckanext/feedback/templates/email_notification
+        email_template_dir = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__), '..', '..', 'templates', 'email_notification'
+            )
         )
-
+        self.template_directory.default = email_template_dir
         self.template_utilization = BaseConfig('template_utilization', parents)
         self.template_utilization.default = 'utilization.text'
 

--- a/ckanext/feedback/services/common/send_mail.py
+++ b/ckanext/feedback/services/common/send_mail.py
@@ -3,15 +3,12 @@ import os
 
 import ckan.lib.mailer
 import ckan.plugins.toolkit as toolkit
+from ckan.common import config
 from jinja2 import Environment, FileSystemLoader
 
 from ckanext.feedback.services.common.config import FeedbackConfig
 
 log = logging.getLogger(__name__)
-DEFAULT_TEMPLATE_DIR = (
-    '/srv/app'
-    + '/src_extensions/ckanext-feedback/ckanext/feedback/templates/email_notification'
-)
 
 
 def send_email(template_name, organization_id, subject, **kwargs):
@@ -20,9 +17,10 @@ def send_email(template_name, organization_id, subject, **kwargs):
         return
 
     # settings email_template and subject from [feedback_config.json > ckan.ini]
-    template_dir = FeedbackConfig().notice_email.template_directory.get()
-    if not os.path.isfile(f'{template_dir}/{template_name}'):
-        template_dir = DEFAULT_TEMPLATE_DIR
+    template_dir = config.get(
+        'ckan.feedback.notice.email.template_directory',
+        FeedbackConfig().notice_email.template_directory.default,
+    )
 
     if not os.path.isfile(f'{template_dir}/{template_name}'):
         log.error(

--- a/ckanext/feedback/tests/services/common/test_send_mail.py
+++ b/ckanext/feedback/tests/services/common/test_send_mail.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import MagicMock, patch
 
 import ckan.lib.mailer
@@ -7,7 +8,7 @@ from ckan import model
 from ckan.common import config
 from jinja2 import Environment, FileSystemLoader
 
-from ckanext.feedback.services.common.send_mail import DEFAULT_TEMPLATE_DIR, send_email
+from ckanext.feedback.services.common.send_mail import send_email
 
 engine = model.repo.session.get_bind()
 
@@ -90,10 +91,21 @@ class TestSendMail:
     def test_send_email_no_template(self, mock_log_error):
         config['ckan.feedback.notice.email.enable'] = True
 
+        email_template_dir = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__),
+                '..',
+                '..',
+                '..',
+                'templates',
+                'email_notification',
+            )
+        )
+
         send_email('no_template.test', '', '')
         mock_log_error.assert_called_once_with(
             'template_file error. %s/%s: No such file or directory',
-            DEFAULT_TEMPLATE_DIR,
+            email_template_dir,
             'no_template.test',
         )
 

--- a/docs/ja/email_notification.md
+++ b/docs/ja/email_notification.md
@@ -58,7 +58,7 @@
     * メールテンプレート名の設定(必須)  
 
         メールテンプレートの格納ディレクトリ内にあるファイルのファイル名を指定してください。  
-        
+
         独自のテンプレートを使用する場合は、メールテンプレートの格納ディレクトリ内にあるファイルの内容を変更するか、別のテンプレートファイルを作成し、そのファイル名を指定してください。
 
         * データリソースへのコメント投稿通知に使用するテンプレート名
@@ -67,7 +67,7 @@
             ckan.feedback.notice.email.template_resource_comment = template.text
             ```
 
-            ※初期テンプレートを使用したい場合は`resource_comment.text`を設定してください。
+            ※初期テンプレートを使用したい場合は[resource_comment.text](../../ckanext/feedback/templates/email_notification/resource_comment.text) を設定してください。
 
         * 利活用の新規投稿通知に使用するテンプレート名
 
@@ -75,7 +75,7 @@
             ckan.feedback.notice.email.template_utilization = template.text
             ```
 
-            ※初期テンプレートを使用したい場合は`utilization.text`を設定してください。
+            ※初期テンプレートを使用したい場合は[utilization.text](../../ckanext/feedback/templates/email_notification/utilization.text)を設定してください。
 
         * 利活用へのコメント投稿通知に使用するテンプレート名
 
@@ -83,7 +83,7 @@
             ckan.feedback.notice.email.template_utilization_comment = template.text
             ```
 
-            ※初期テンプレートを使用したい場合は`utilization_comment.text`を設定してください。
+            ※初期テンプレートを使用したい場合は[utilization_comment.text](../../ckanext/feedback/templates/email_notification/utilization_comment.text)を設定してください。
 
     * 件名の指定 (任意)
 

--- a/docs/ja/email_notification.md
+++ b/docs/ja/email_notification.md
@@ -53,30 +53,37 @@
         ckan.feedback.notice.email.template_directory = /path/to/template_dir
         ```
 
-        ※設定されていない場合は`{ckan.iniがあるディレクトリ}/src_extensions/ckanext-feedback/ckanext/feedback/templates/email_notification`が使用される。
+        ※設定されていない場合は`{ckanext-feedbackがインストールされているディレクトリ}/templates/email_notification`が使用される。
 
-    * メールテンプレート名の設定(必須)
+    * メールテンプレート名の設定(必須)  
+
+        メールテンプレートの格納ディレクトリ内にあるファイルのファイル名を指定してください。  
+        
+        独自のテンプレートを使用する場合は、メールテンプレートの格納ディレクトリ内にあるファイルの内容を変更するか、別のテンプレートファイルを作成し、そのファイル名を指定してください。
 
         * データリソースへのコメント投稿通知に使用するテンプレート名
 
             ```ini
-            ckan.feedback.notice.email.template_resource_comment = resource_comment.text
+            ckan.feedback.notice.email.template_resource_comment = template.text
             ```
+
+            ※初期テンプレートを使用したい場合は`resource_comment.text`を設定してください。
 
         * 利活用の新規投稿通知に使用するテンプレート名
 
             ```ini
-            ckan.feedback.notice.email.template_utilization = utilization.text
+            ckan.feedback.notice.email.template_utilization = template.text
             ```
+
+            ※初期テンプレートを使用したい場合は`utilization.text`を設定してください。
 
         * 利活用へのコメント投稿通知に使用するテンプレート名
 
             ```ini
-            ckan.feedback.notice.email.template_utilization_comment = utilization_comment.text
+            ckan.feedback.notice.email.template_utilization_comment = template.text
             ```
 
-        ※ メールテンプレートの格納ディレクトリ内にあるファイルのファイル名を指定してください。  
-        ※ 独自のテンプレートを使用する場合は、メールテンプレートの格納ディレクトリ内にあるファイルの内容を変更するか、別なテンプレートファイルを作成し、そのファイル名を指定してください。
+            ※初期テンプレートを使用したい場合は`utilization_comment.text`を設定してください。
 
     * 件名の指定 (任意)
 


### PR DESCRIPTION
ckan.iniにメールテンプレートの格納ディレクトリの指定しなかった場合に、ハードコードされたデフォルトディレクトリを設定していたところを、パッケージに含まれるデフォルトディレクトリを動的に設定するように修正をしました。