### PR TITLE
返信コメントでバリデーションエラー後に送信ボタンが再度押せない不具合を修正

### DIFF
--- a/ckanext/feedback/assets/js/comment.js
+++ b/ckanext/feedback/assets/js/comment.js
@@ -42,17 +42,23 @@ function checkCommentExists(button, bs3=false) {
 }
 
 function checkReplyExists(button) {
+  button.style.pointerEvents = 'none';
+
   const errorElement = document.getElementById('reply-error');
   const reply = document.getElementById('reply_content').value;
-  button.style.pointerEvents = "none"
 
-  if (reply) {
-    errorElement.style.display = 'none';
-    return true;
-  } else {
-    errorElement.style.display = '';
-    return false;
+  errorElement.style.display = 'none';
+  
+  let is_reply_exists = true;
+
+  if (!reply) {
+    errorElement.style.display = 'block';
+    is_reply_exists = false;
   }
+
+  button.style.pointerEvents = 'auto';
+
+  return is_reply_exists;
 }
 
 function selectRating(selectedStar) {


### PR DESCRIPTION
**発見経緯：**
返信コメントフォームで入力ミスがあった場合、バリデーションエラーが発生しエラーメッセージが表示されるものの、送信ボタンが非活性のままとなり、ユーザーが再度送信操作を行えない問題が発生していました。

**期待動作：**
バリデーションエラーが発生した場合でも、適切にエラーメッセージを表示し、ユーザーが内容を修正した後に再度送信ボタンを押せる状態になること。

**修正内容：**
バリデーションチェックでエラーが発生した際にも、送信ボタンを再度活性化する処理を追加しました。