### PR TITLE
権限のないユーザーによるメール送信で発生する不具合の解消

### DIFF
--- a/ckanext/feedback/services/common/send_mail.py
+++ b/ckanext/feedback/services/common/send_mail.py
@@ -43,11 +43,15 @@ def send_email(template_name, organization_id, subject, **kwargs):
     )
 
     # Retrieving organization administrators and sending emails
+    context = {'ignore_auth': True, 'keep_email': True}
+
     get_members = toolkit.get_action('member_list')
     show_user = toolkit.get_action('user_show')
 
     condition = {'id': organization_id, 'object_type': 'user', 'capacity': 'admin'}
-    users = [show_user(None, {'id': id}) for (id, _, _) in get_members(None, condition)]
+    users = [
+        show_user(context, {'id': id}) for (id, _, _) in get_members(context, condition)
+    ]
 
     for user in users:
         try:


### PR DESCRIPTION
**事象**
未ログインユーザーまたは権限のないユーザーによる以下の操作において、組織管理者への通知メールが送信されない事象を修正します。
- リソースコメント投稿
- 利活用方法登録申請
- 利活用コメント投稿

**原因**
- メール送信に使用している内部関数で権限チェックが行われており、未ログイン・非権限ユーザーは処理が中断されていた。
- 組織管理者の詳細情報取得時に、権限のないユーザーからのアクセスではメールアドレスがマスキングされていた。

**対応**
- メール送信関数における 権限チェックをスキップ するよう変更
- 組織管理者情報取得時に マスキングを抑制 するよう変更
