### PR TITLE
メールに記載するコメントカテゴリのi18n対応

### DIFF
--- a/ckanext/feedback/controllers/resource.py
+++ b/ckanext/feedback/controllers/resource.py
@@ -111,6 +111,12 @@ class ResourceController:
         summary_service.create_resource_summary(resource_id)
         session.commit()
 
+        category_map = {
+            ResourceCommentCategory.REQUEST.name: _('Request'),
+            ResourceCommentCategory.QUESTION.name: _('Question'),
+            ResourceCommentCategory.THANK.name: _('Thank'),
+        }
+
         try:
             resource = comment_service.get_resource(resource_id)
             send_email(
@@ -120,7 +126,7 @@ class ResourceController:
                 organization_id=resource.Resource.package.owner_org,
                 subject=FeedbackConfig().notice_email.subject_resource_comment.get(),
                 target_name=resource.Resource.name,
-                category=category,
+                category=category_map[category],
                 content=content,
                 url=toolkit.url_for(
                     'resource_comment.comment', resource_id=resource_id, _external=True

--- a/ckanext/feedback/controllers/utilization.py
+++ b/ckanext/feedback/controllers/utilization.py
@@ -300,6 +300,12 @@ class UtilizationController:
         detail_service.create_utilization_comment(utilization_id, category, content)
         session.commit()
 
+        category_map = {
+            UtilizationCommentCategory.REQUEST.name: _('Request'),
+            UtilizationCommentCategory.QUESTION.name: _('Question'),
+            UtilizationCommentCategory.THANK.name: _('Thank'),
+        }
+
         try:
             utilization = detail_service.get_utilization(utilization_id)
             send_email(
@@ -311,7 +317,7 @@ class UtilizationController:
                 ).Resource.package.owner_org,
                 subject=FeedbackConfig().notice_email.subject_utilization_comment.get(),
                 target_name=utilization.title,
-                category=category,
+                category=category_map[category],
                 content=content,
                 url=toolkit.url_for(
                     'utilization.details', utilization_id=utilization_id, _external=True

--- a/ckanext/feedback/i18n/ja/LC_MESSAGES/ckanext-feedback.po
+++ b/ckanext/feedback/i18n/ja/LC_MESSAGES/ckanext-feedback.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-feedback 1.3.6\n"
 "Report-Msgid-Bugs-To: info.c3lab@gmail.com\n"
-"POT-Creation-Date: 2025-06-29 10:28+0900\n"
+"POT-Creation-Date: 2025-06-30 11:21+0900\n"
 "PO-Revision-Date: 2023-03-01 14:16+0900\n"
 "Last-Translator: c3Lab <info.c3lab@gmail.com>\n"
 "Language: ja\n"
@@ -187,8 +187,8 @@ msgstr "項目を完全に削除しました。"
 #: ckanext/feedback/controllers/admin.py:342
 #: ckanext/feedback/controllers/admin.py:357
 #: ckanext/feedback/controllers/admin.py:375
-#: ckanext/feedback/controllers/resource.py:288
-#: ckanext/feedback/controllers/utilization.py:561
+#: ckanext/feedback/controllers/resource.py:294
+#: ckanext/feedback/controllers/utilization.py:567
 #: ckanext/feedback/services/common/check.py:13
 #: ckanext/feedback/tests/controllers/test_admin.py:889
 #: ckanext/feedback/tests/controllers/test_admin.py:915
@@ -270,15 +270,36 @@ msgid "feedback_all_time_report"
 msgstr "フィードバック全期間レポート"
 
 #: ckanext/feedback/controllers/resource.py:97
-#: ckanext/feedback/controllers/resource.py:206
+#: ckanext/feedback/controllers/resource.py:212
 #: ckanext/feedback/controllers/utilization.py:167
 #: ckanext/feedback/controllers/utilization.py:286
-#: ckanext/feedback/controllers/utilization.py:387
+#: ckanext/feedback/controllers/utilization.py:393
 msgid "Bad Captcha. Please try again."
 msgstr "認証に失敗しました。 もう一度お試しください。"
 
-#: ckanext/feedback/controllers/resource.py:133
-#: ckanext/feedback/controllers/utilization.py:324
+#: ckanext/feedback/controllers/resource.py:115
+#: ckanext/feedback/controllers/utilization.py:304
+#: ckanext/feedback/migration/feedback/versions/000_40bf9a900ef5_init.py:25
+#: ckanext/feedback/migration/feedback/versions/000_40bf9a900ef5_init.py:31
+msgid "Request"
+msgstr "要望"
+
+#: ckanext/feedback/controllers/resource.py:116
+#: ckanext/feedback/controllers/utilization.py:305
+#: ckanext/feedback/migration/feedback/versions/000_40bf9a900ef5_init.py:26
+#: ckanext/feedback/migration/feedback/versions/000_40bf9a900ef5_init.py:32
+msgid "Question"
+msgstr "質問"
+
+#: ckanext/feedback/controllers/resource.py:117
+#: ckanext/feedback/controllers/utilization.py:306
+#: ckanext/feedback/migration/feedback/versions/000_40bf9a900ef5_init.py:27
+#: ckanext/feedback/migration/feedback/versions/000_40bf9a900ef5_init.py:33
+msgid "Thank"
+msgstr "感謝"
+
+#: ckanext/feedback/controllers/resource.py:139
+#: ckanext/feedback/controllers/utilization.py:330
 msgid ""
 "Your comment has been sent.<br>The comment will not be displayed until "
 "approved by an administrator."
@@ -290,28 +311,13 @@ msgid ""
 "until approved by an administrator."
 msgstr "登録申請が完了しました。<br>管理者に申請が承認されるまで表示されません。"
 
-#: ckanext/feedback/controllers/utilization.py:511
+#: ckanext/feedback/controllers/utilization.py:517
 msgid "The utilization has been successfully updated."
 msgstr "利活用方法の更新に成功しました。"
 
-#: ckanext/feedback/controllers/utilization.py:529
+#: ckanext/feedback/controllers/utilization.py:535
 msgid "The utilization has been successfully deleted."
 msgstr "利活用方法の削除に成功しました。"
-
-#: ckanext/feedback/migration/feedback/versions/000_40bf9a900ef5_init.py:25
-#: ckanext/feedback/migration/feedback/versions/000_40bf9a900ef5_init.py:31
-msgid "Request"
-msgstr "要望"
-
-#: ckanext/feedback/migration/feedback/versions/000_40bf9a900ef5_init.py:26
-#: ckanext/feedback/migration/feedback/versions/000_40bf9a900ef5_init.py:32
-msgid "Question"
-msgstr "質問"
-
-#: ckanext/feedback/migration/feedback/versions/000_40bf9a900ef5_init.py:27
-#: ckanext/feedback/migration/feedback/versions/000_40bf9a900ef5_init.py:33
-msgid "Thank"
-msgstr "感謝"
 
 #: ckanext/feedback/templates/header.html:11
 msgid "Sysadmin settings"

--- a/ckanext/feedback/templates/email_notification/resource_comment.text
+++ b/ckanext/feedback/templates/email_notification/resource_comment.text
@@ -1,6 +1,6 @@
 Dear Organization Administrator,
 
-We have received a new comment regarding {{ target }}. Please review the details of the comment below:
+We have received a new comment regarding {{ target_name }}. Please review the details of the comment below:
 
 Comment Category: {{ category }}
 

--- a/ckanext/feedback/templates/email_notification/utilization.text
+++ b/ckanext/feedback/templates/email_notification/utilization.text
@@ -1,6 +1,6 @@
 Dear Organization Administrator,
 
-We are writing to notify you that a new submission related to {{ target }} has been received. Please review the details of the submission below:
+We are writing to notify you that a new submission related to {{ target_name }} has been received. Please review the details of the submission below:
 
 Submission Title: {{ content_title }}
 

--- a/ckanext/feedback/templates/email_notification/utilization_comment.text
+++ b/ckanext/feedback/templates/email_notification/utilization_comment.text
@@ -1,6 +1,6 @@
 Dear Organization Administrator,
 
-We have received a new comment regarding {{ target }}. Please review the details of the comment below:
+We have received a new comment regarding {{ target_name }}. Please review the details of the comment below:
 
 Comment Category: {{ category }}
 

--- a/ckanext/feedback/tests/controllers/test_resource.py
+++ b/ckanext/feedback/tests/controllers/test_resource.py
@@ -16,6 +16,7 @@ from ckanext.feedback.command.feedback import (
     create_utilization_tables,
 )
 from ckanext.feedback.controllers.resource import ResourceController
+from ckanext.feedback.models.resource_comment import ResourceCommentCategory
 from ckanext.feedback.models.session import session
 
 engine = model.repo.session.get_bind()
@@ -372,7 +373,7 @@ class TestResourceController:
         mock_form,
     ):
         resource_id = 'resource id'
-        category = 'category'
+        category = ResourceCommentCategory.REQUEST.name
         comment_content = 'content'
         rating = '1'
         package_name = 'ota'
@@ -449,7 +450,7 @@ class TestResourceController:
         mock_form,
     ):
         resource_id = 'resource id'
-        category = 'category'
+        category = ResourceCommentCategory.REQUEST.name
         content = 'ex'
         while True:
             content += content
@@ -484,7 +485,7 @@ class TestResourceController:
     ):
         resource_id = 'resource_id'
         comment_content = 'comment_content'
-        category = 'category'
+        category = ResourceCommentCategory.REQUEST.name
         package_name = 'ota'
         mock_form.get.side_effect = lambda x, default: {
             'package_name': package_name,

--- a/ckanext/feedback/tests/controllers/test_utilization.py
+++ b/ckanext/feedback/tests/controllers/test_utilization.py
@@ -16,6 +16,7 @@ from ckanext.feedback.command.feedback import (
     create_utilization_tables,
 )
 from ckanext.feedback.controllers.utilization import UtilizationController
+from ckanext.feedback.models.utilization import UtilizationCommentCategory
 
 engine = model.repo.session.get_bind()
 
@@ -1466,7 +1467,7 @@ class TestUtilizationController:
         mock_form,
     ):
         utilization_id = 'utilization id'
-        category = 'category'
+        category = UtilizationCommentCategory.REQUEST.name
         content = 'content'
 
         mock_form.get.side_effect = [category, content, True]
@@ -1513,7 +1514,7 @@ class TestUtilizationController:
         mock_form,
     ):
         utilization_id = 'utilization id'
-        category = 'category'
+        category = UtilizationCommentCategory.REQUEST.name
         content = 'ex'
         while True:
             content += content
@@ -1546,7 +1547,7 @@ class TestUtilizationController:
         mock_form,
     ):
         utilization_id = 'utilization_id'
-        category = 'category'
+        category = UtilizationCommentCategory.REQUEST.name
         content = 'content'
 
         mock_form.get.side_effect = [


### PR DESCRIPTION
**概要**
メール本文に表示されるコメントのカテゴリ（Request、Question、Thank）について、国際化（i18n）対応を行いました。

**問題点**
コメントカテゴリの文言は固定の英語表記であり、他言語環境での利用時に適切に翻訳されていませんでした。

**解決方法**
- 各カテゴリ（Request、Question、Thank）に対する翻訳可能な表示文字列をマッピング