### PR TITLE
データセット画面にある利活用方法の件数表示の統一

### DIFF
--- a/ckanext/feedback/templates/package/snippets/resource_item.html
+++ b/ckanext/feedback/templates/package/snippets/resource_item.html
@@ -2,7 +2,6 @@
 
 {% block resource_item_title %}
   {% asset 'feedback/feedback-tooltip-css' %}
-  {% asset 'feedback/feedback-tooltip-css' %}
   <a class="heading" href="{{ url }}" title="{{ res.name or res.description }}">
     {{ h.resource_display_name(res) | truncate(50) }}<span class="format-label" property="dc:format" data-format="{{ res.format.lower() or 'data' }}">{{ h.get_translated(res, 'format') }}</span>
     {{ h.popular('views', res.tracking_summary.total, min=10) if res.tracking_summary }}
@@ -26,7 +25,7 @@
   {% endif %}
   {% if h.is_enabled_downloads(pkg.owner_org) %}
     <a style="color: inherit; text-decoration: none;" href="{{ h.url_for('resource.read', id=pkg.id, resource_id=res.id, package_type='dataset') }}">
-      <div class = "bubble">
+      <div class="bubble">
         <i class="fa-solid fa-arrow-circle-down" style="vertical-align: middle;"></i>
         {{ h.get_resource_downloads(res.id) }}
         <div class="bubbleText">{{ _('Downloads') }}</div>

--- a/ckanext/feedback/templates/snippets/package_item.html
+++ b/ckanext/feedback/templates/snippets/package_item.html
@@ -33,11 +33,13 @@
   </li>
   <li>
     {% if h.is_enabled_utilizations(package.owner_org) %}
-      <div class="utilization-data bubble">
-        <i class="fa-solid fa-seedling" style="vertical-align: middle;"></i>
-        <a href="{{ h.url_for('utilization.search', id=package.id, disable_keyword=true) }}">{{ h.get_package_utilizations(package.id) }}</a>
-        <div class="bubbleText">{{ _('Utilizations') }}</div>
-      </div>
+      <a style="color: inherit; text-decoration: none; background-color: transparent;" href="{{ h.url_for('utilization.search', id=package.id, disable_keyword=true) }}">
+        <div class="utilization-data bubble">
+          <i class="fa-solid fa-seedling" style="vertical-align: middle;"></i>
+            {{ h.get_package_utilizations(package.id) }}
+          <div class="bubbleText">{{ _('Utilizations') }}</div>
+        </div>
+      </a>
     {% endif %}
   </li>
   <li>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c5f48e87-dbf7-4c7a-b02c-9bb045ad7f3f)　![image](https://github.com/user-attachments/assets/49424c08-891e-41b4-8187-f831684f4246)

**概要**
利活用方法の件数表示が、他の件数表示（例：いいね数、コメント数など）とスタイルに差異があることが確認されました。

**原因**
利活用方法の件数表示にのみ、スタイル（フォントサイズ・色など）が適用されていなかったため、他と見た目に差が出ていた。

**対応内容**
利活用方法の件数表示に共通のスタイルを適用し、他の件数表示と統一しました。

**補足**
UI上の統一感を保つためのデザイン調整であり、機能的なロジックの変更はありません。
