### PR TITLE
ダウンロード機能がOFFのときにエンドポイントを呼び出すテンプレートのエラーを修正

### DIFF
--- a/ckanext/feedback/templates/package/snippets/resource_item.html
+++ b/ckanext/feedback/templates/package/snippets/resource_item.html
@@ -113,15 +113,19 @@
           {% if res.url and h.is_url(res.url) %}
             <li>
               {% if res.has_views or res.url_type == 'upload' %}
-              {% if h.is_enabled_downloads() %}
-              <a class="dropdown-item resource-url-analytics" href="{{ h.url_for('download.download', id=pkg.id, resource_id=res.id) }}?user-download=true" target="_blank" rel="noreferrer" download>
-              {% else %}
-              <a class="dropdown-item resource-url-analytics" href="{{ res.url }}" target="_blank" rel="noreferrer">
-              {% endif %}
+                {% if h.is_enabled_downloads() %}
+                  <a class="dropdown-item resource-url-analytics" href="{{ h.url_for('download.download', id=pkg.id, resource_id=res.id) }}?user-download=true" target="_blank" rel="noreferrer" download>
+                {% else %}
+                  <a class="dropdown-item resource-url-analytics" href="{{ res.url }}" target="_blank" rel="noreferrer">
+                {% endif %}
                 <i class="fa fa-arrow-circle-down"></i>
                 {{ _('Download') }}
               {% else %}
-              <a class="dropdown-item resource-url-analytics" href="{{ h.url_for('download.download', id=pkg.id, resource_id=res.id) }}" target="_blank" rel="noreferrer">
+                {% if h.is_enabled_downloads() %}
+                  <a class="dropdown-item resource-url-analytics" href="{{ h.url_for('download.download', id=pkg.id, resource_id=res.id) }}" target="_blank" rel="noreferrer">
+                {% else %}
+                  <a class="dropdown-item resource-url-analytics" href="{{ res.url }}" target="_blank" rel="noreferrer">
+                {% endif %}
                 <i class="fa fa-external-link"></i>
                 {{ _('Go to resource') }}
               {% endif %}


### PR DESCRIPTION
**概要**
ダウンロードモジュールを OFF にしている状態で、表示用 URL をアップロードしているリソースを含むデータセット画面に遷移すると、
リソースごとにダウンロードモジュールのドロップダウンを生成する処理が動作します。
しかし、その際に a タグの生成時に指定されたエンドポイントが Flask 上に存在しておらず、`BuildError` が発生してしまいます。

**原因**
ダウンロードモジュールに関連する Blueprint の登録は、モジュールが ON の場合のみ実行される仕様です。
一方で、モジュールが OFF の状態でもテンプレート側ではそのエンドポイントを呼び出そうとするため、未定義の状態で `BuildError` が発生します。

**対応**
テンプレート側で、ダウンロードモジュールが OFF の場合には別の a タグを出力するよう処理を分岐させます。