### PR TITLE
Refactor cookie configuration into separate files

### DIFF
--- a/ckanext/feedback/controllers/cookie.py
+++ b/ckanext/feedback/controllers/cookie.py
@@ -1,13 +1,17 @@
 from flask import request
 
-def set_like_status_cookie(resp,resource_id,like_status):
-    if like_status not in ["True","False"]:
+
+def set_like_status_cookie(resp, resource_id, like_status):
+    if like_status not in ["True", "False"]:
         raise ValueError("like_status must be 'True' or 'False'")
     resp.set_cookie(f'like_status_{resource_id}', f'{like_status}', max_age=2147483647)
     return resp
 
-def set_repeat_post_limit_cookie(resp,resource_id):
-    resp.set_cookie(f'repeat_post_limit_{resource_id}', 'alreadyPosted', max_age=2147483647)
+
+def set_repeat_post_limit_cookie(resp, resource_id):
+    resp.set_cookie(
+        f'repeat_post_limit_{resource_id}', 'alreadyPosted', max_age=2147483647
+    )
     return resp
 
 

--- a/ckanext/feedback/controllers/cookie.py
+++ b/ckanext/feedback/controllers/cookie.py
@@ -1,0 +1,17 @@
+from flask import request
+
+def set_like_status_cookie(resp,resource_id,like_status):
+    resp.set_cookie(f'like_status_{resource_id}', f'{like_status}', max_age=2147483647)
+    return resp
+
+def set_repeat_post_limit_cookie(resp,resource_id):
+    resp.set_cookie(f'repeat_post_limit_{resource_id}', 'alreadyPosted', max_age=2147483647)
+    return resp
+
+
+def get_like_status_cookie(resource_id):
+    return request.cookies.get(f'like_status_{resource_id}')
+
+
+def get_repeat_post_limit_cookie(resource_id):
+    return request.cookies.get(f'repeat_post_limit_{resource_id}')

--- a/ckanext/feedback/controllers/cookie.py
+++ b/ckanext/feedback/controllers/cookie.py
@@ -1,6 +1,8 @@
 from flask import request
 
 def set_like_status_cookie(resp,resource_id,like_status):
+    if like_status not in ["True","False"]:
+        raise ValueError("like_status must be 'True' or 'False'")
     resp.set_cookie(f'like_status_{resource_id}', f'{like_status}', max_age=2147483647)
     return resp
 

--- a/ckanext/feedback/controllers/resource.py
+++ b/ckanext/feedback/controllers/resource.py
@@ -30,6 +30,12 @@ from ckanext.feedback.services.common.check import (
 from ckanext.feedback.services.common.config import FeedbackConfig
 from ckanext.feedback.services.common.send_mail import send_email
 from ckanext.feedback.services.recaptcha.check import is_recaptcha_verified
+from ckanext.feedback.controllers.cookie import (
+    set_like_status_cookie,
+    set_repeat_post_limit_cookie,
+    get_like_status_cookie,
+    get_repeat_post_limit_cookie
+)
 
 log = logging.getLogger(__name__)
 
@@ -60,7 +66,7 @@ class ResourceController:
         )
 
         categories = comment_service.get_resource_comment_categories()
-        cookie = comment_service.get_cookie(resource_id)
+        cookie = get_repeat_post_limit_cookie(resource_id)
         context = {'model': model, 'session': session, 'for_view': True}
         package = get_action('package_show')(
             context, {'id': resource.Resource.package_id}
@@ -179,7 +185,7 @@ class ResourceController:
             )
         )
 
-        resp.set_cookie(resource_id, 'alreadyPosted')
+        resp = set_repeat_post_limit_cookie(resp,resource_id)
 
         return resp
 
@@ -395,7 +401,8 @@ class ResourceController:
             )
 
     def like_status(resource_id):
-        status = comment_service.get_cookie(resource_id)
+
+        status = get_like_status_cookie(resource_id)
         if status:
             return status
         return 'False'
@@ -415,7 +422,8 @@ class ResourceController:
         session.commit()
 
         resp = Response("OK", status=200, mimetype='text/plain')
-        resp.set_cookie(resource_id, f'{like_status}', max_age=2147483647)
+        resp =  set_like_status_cookie(resp,resource_id,like_status)
+
         return resp
 
     # resource_comment/<resource_id>/comment/reactions

--- a/ckanext/feedback/services/resource/comment.py
+++ b/ckanext/feedback/services/resource/comment.py
@@ -6,7 +6,6 @@ from ckan.model.group import Group
 from ckan.model.package import Package
 from ckan.model.resource import Resource
 from ckan.types import PUploader
-from flask import request
 from sqlalchemy.orm import joinedload
 
 from ckanext.feedback.models.resource_comment import (
@@ -142,6 +141,7 @@ def create_reply(resource_comment_id, content, creator_user_id):
         creator_user_id=creator_user_id,
     )
     session.add(reply)
+
 
 def get_resource_comment_reactions(resource_comment_id):
     result = (

--- a/ckanext/feedback/services/resource/comment.py
+++ b/ckanext/feedback/services/resource/comment.py
@@ -143,12 +143,6 @@ def create_reply(resource_comment_id, content, creator_user_id):
     )
     session.add(reply)
 
-
-# Get cookie
-def get_cookie(resource_id):
-    return request.cookies.get(resource_id)
-
-
 def get_resource_comment_reactions(resource_comment_id):
     result = (
         session.query(ResourceCommentReactions)

--- a/ckanext/feedback/tests/controllers/test_cookie.py
+++ b/ckanext/feedback/tests/controllers/test_cookie.py
@@ -1,11 +1,13 @@
 import pytest
 from flask import Flask, make_response
+
 from ckanext.feedback.controllers.cookie import (
-    set_like_status_cookie,
-    set_repeat_post_limit_cookie,
     get_like_status_cookie,
     get_repeat_post_limit_cookie,
+    set_like_status_cookie,
+    set_repeat_post_limit_cookie,
 )
+
 
 @pytest.fixture
 def app():
@@ -16,28 +18,31 @@ def app():
 
 def test_set_like_status_cookie_true(app):
     with app.test_client() as client:
-        
+
         @app.route("/set_true")
         def set_cookie_true():
             resp = make_response("OK")
-            return set_like_status_cookie(resp,"123","True")
+            return set_like_status_cookie(resp, "123", "True")
+
         res = client.get("/set_true")
         cookie = res.headers.get("Set-Cookie")
         assert "like_status_123=True" in cookie
         assert "Max-Age=2147483647" in cookie
 
+
 def test_set_like_status_cookie_false(app):
     with app.test_client() as client:
-
 
         @app.route("/set_false")
         def set_cookie_false():
             resp = make_response("OK")
-            return set_like_status_cookie(resp,"123","False")
+            return set_like_status_cookie(resp, "123", "False")
+
         res = client.get("/set_false")
         cookie = res.headers.get("Set-Cookie")
         assert "like_status_123=False" in cookie
         assert "Max-Age=2147483647" in cookie
+
 
 def test_set_like_status_cookie_invalid_value_raises(app):
     with app.test_request_context():
@@ -45,8 +50,10 @@ def test_set_like_status_cookie_invalid_value_raises(app):
         with pytest.raises(ValueError):
             set_like_status_cookie(resp, "abc", "maybe")
 
+
 def test_set_repeat_post_limit_cookie_nomal(app):
-     with app.test_client() as client:
+    with app.test_client() as client:
+
         @app.route("/set_cookie")
         def set_cookie_nomal():
             resp = make_response("OK")
@@ -57,8 +64,10 @@ def test_set_repeat_post_limit_cookie_nomal(app):
         assert "repeat_post_limit_123=alreadyPosted" in cookie
         assert "Max-Age=2147483647" in cookie
 
+
 def test_set_repeat_post_limit_cookie_empty_id(app):
     with app.test_client() as client:
+
         @app.route("/set_cookie_empty")
         def set_cookie_empty():
             resp = make_response("OK")
@@ -68,8 +77,10 @@ def test_set_repeat_post_limit_cookie_empty_id(app):
         cookie = res.headers.get("Set-Cookie")
         assert "repeat_post_limit_=alreadyPosted" in cookie
 
+
 def test_set_repeat_post_limit_cookie_numeric_id(app):
     with app.test_client() as client:
+
         @app.route("/set_cookie_num")
         def set_cookie_numeric():
             resp = make_response("OK")
@@ -79,8 +90,10 @@ def test_set_repeat_post_limit_cookie_numeric_id(app):
         cookie = res.headers.get("Set-Cookie")
         assert "repeat_post_limit_456=alreadyPosted" in cookie
 
+
 def test_set_repeat_post_limit_cookie_none_id(app):
     with app.test_client() as client:
+
         @app.route("/set_cookie_none")
         def set_cookie_none():
             resp = make_response("OK")
@@ -90,8 +103,10 @@ def test_set_repeat_post_limit_cookie_none_id(app):
         cookie = res.headers.get("Set-Cookie")
         assert "repeat_post_limit_None=alreadyPosted" in cookie
 
+
 def test_get_like_status_cookie_true(app):
     with app.test_client() as client:
+
         @app.route("/get_cookie")
         def get_cookie_true():
             return get_like_status_cookie("123") or "None"
@@ -100,8 +115,10 @@ def test_get_like_status_cookie_true(app):
         res = client.get("/get_cookie")
         assert res.data.decode() == "true"
 
+
 def test_get_like_status_cookie_false(app):
     with app.test_client() as client:
+
         @app.route("/get_cookie")
         def get_cookie_false():
             return get_like_status_cookie("456") or "None"
@@ -110,8 +127,10 @@ def test_get_like_status_cookie_false(app):
         res = client.get("/get_cookie")
         assert res.data.decode() == "false"
 
+
 def test_get_like_status_cookie_none(app):
     with app.test_client() as client:
+
         @app.route("/get_cookie")
         def get_cookie_none():
             return get_like_status_cookie("789") or "None"
@@ -119,8 +138,10 @@ def test_get_like_status_cookie_none(app):
         res = client.get("/get_cookie")
         assert res.data.decode() == "None"
 
+
 def test_get_like_status_cookie_empty_id(app):
     with app.test_client() as client:
+
         @app.route("/get_cookie")
         def get_cookie_empty():
             return get_like_status_cookie("") or "None"
@@ -129,8 +150,10 @@ def test_get_like_status_cookie_empty_id(app):
         res = client.get("/get_cookie")
         assert res.data.decode() == "true"
 
+
 def test_get_repeat_post_limit_cookie_set(app):
     with app.test_client() as client:
+
         @app.route("/get_repeat_cookie")
         def get_cookie_nomal():
             return get_repeat_post_limit_cookie("123") or "None"
@@ -139,8 +162,10 @@ def test_get_repeat_post_limit_cookie_set(app):
         res = client.get("/get_repeat_cookie")
         assert res.data.decode() == "alreadyPosted"
 
+
 def test_get_repeat_post_limit_cookie_none(app):
     with app.test_client() as client:
+
         @app.route("/get_repeat_cookie")
         def get_cookie_none():
             return get_repeat_post_limit_cookie("456") or "None"
@@ -148,8 +173,10 @@ def test_get_repeat_post_limit_cookie_none(app):
         res = client.get("/get_repeat_cookie")
         assert res.data.decode() == "None"
 
+
 def test_get_repeat_post_limit_cookie_empty_id(app):
     with app.test_client() as client:
+
         @app.route("/get_repeat_cookie")
         def get_cookie_empty():
             return get_repeat_post_limit_cookie("") or "None"
@@ -158,8 +185,10 @@ def test_get_repeat_post_limit_cookie_empty_id(app):
         res = client.get("/get_repeat_cookie")
         assert res.data.decode() == "alreadyPosted"
 
+
 def test_get_repeat_post_limit_cookie_special_id(app):
     with app.test_client() as client:
+
         @app.route("/get_repeat_cookie")
         def get_cookie_special():
             return get_repeat_post_limit_cookie("@!#") or "None"

--- a/ckanext/feedback/tests/controllers/test_cookie.py
+++ b/ckanext/feedback/tests/controllers/test_cookie.py
@@ -1,0 +1,169 @@
+import pytest
+from flask import Flask, make_response
+from ckanext.feedback.controllers.cookie import (
+    set_like_status_cookie,
+    set_repeat_post_limit_cookie,
+    get_like_status_cookie,
+    get_repeat_post_limit_cookie,
+)
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    return app
+
+
+def test_set_like_status_cookie_true(app):
+    with app.test_client() as client:
+        
+        @app.route("/set_true")
+        def set_cookie_true():
+            resp = make_response("OK")
+            return set_like_status_cookie(resp,"123","True")
+        res = client.get("/set_true")
+        cookie = res.headers.get("Set-Cookie")
+        assert "like_status_123=True" in cookie
+        assert "Max-Age=2147483647" in cookie
+
+def test_set_like_status_cookie_false(app):
+    with app.test_client() as client:
+
+
+        @app.route("/set_false")
+        def set_cookie_false():
+            resp = make_response("OK")
+            return set_like_status_cookie(resp,"123","False")
+        res = client.get("/set_false")
+        cookie = res.headers.get("Set-Cookie")
+        assert "like_status_123=False" in cookie
+        assert "Max-Age=2147483647" in cookie
+
+def test_set_like_status_cookie_invalid_value_raises(app):
+    with app.test_request_context():
+        resp = make_response("OK")
+        with pytest.raises(ValueError):
+            set_like_status_cookie(resp, "abc", "maybe")
+
+def test_set_repeat_post_limit_cookie_nomal(app):
+     with app.test_client() as client:
+        @app.route("/set_cookie")
+        def set_cookie_nomal():
+            resp = make_response("OK")
+            return set_repeat_post_limit_cookie(resp, "123")
+
+        res = client.get("/set_cookie")
+        cookie = res.headers.get("Set-Cookie")
+        assert "repeat_post_limit_123=alreadyPosted" in cookie
+        assert "Max-Age=2147483647" in cookie
+
+def test_set_repeat_post_limit_cookie_empty_id(app):
+    with app.test_client() as client:
+        @app.route("/set_cookie_empty")
+        def set_cookie_empty():
+            resp = make_response("OK")
+            return set_repeat_post_limit_cookie(resp, "")
+
+        res = client.get("/set_cookie_empty")
+        cookie = res.headers.get("Set-Cookie")
+        assert "repeat_post_limit_=alreadyPosted" in cookie
+
+def test_set_repeat_post_limit_cookie_numeric_id(app):
+    with app.test_client() as client:
+        @app.route("/set_cookie_num")
+        def set_cookie_numeric():
+            resp = make_response("OK")
+            return set_repeat_post_limit_cookie(resp, 456)
+
+        res = client.get("/set_cookie_num")
+        cookie = res.headers.get("Set-Cookie")
+        assert "repeat_post_limit_456=alreadyPosted" in cookie
+
+def test_set_repeat_post_limit_cookie_none_id(app):
+    with app.test_client() as client:
+        @app.route("/set_cookie_none")
+        def set_cookie_none():
+            resp = make_response("OK")
+            return set_repeat_post_limit_cookie(resp, None)
+
+        res = client.get("/set_cookie_none")
+        cookie = res.headers.get("Set-Cookie")
+        assert "repeat_post_limit_None=alreadyPosted" in cookie
+
+def test_get_like_status_cookie_true(app):
+    with app.test_client() as client:
+        @app.route("/get_cookie")
+        def get_cookie_true():
+            return get_like_status_cookie("123") or "None"
+
+        client.set_cookie("localhost", "like_status_123", "true")
+        res = client.get("/get_cookie")
+        assert res.data.decode() == "true"
+
+def test_get_like_status_cookie_false(app):
+    with app.test_client() as client:
+        @app.route("/get_cookie")
+        def get_cookie_false():
+            return get_like_status_cookie("456") or "None"
+
+        client.set_cookie("localhost", "like_status_456", "false")
+        res = client.get("/get_cookie")
+        assert res.data.decode() == "false"
+
+def test_get_like_status_cookie_none(app):
+    with app.test_client() as client:
+        @app.route("/get_cookie")
+        def get_cookie_none():
+            return get_like_status_cookie("789") or "None"
+
+        res = client.get("/get_cookie")
+        assert res.data.decode() == "None"
+
+def test_get_like_status_cookie_empty_id(app):
+    with app.test_client() as client:
+        @app.route("/get_cookie")
+        def get_cookie_empty():
+            return get_like_status_cookie("") or "None"
+
+        client.set_cookie("localhost", "like_status_", "true")
+        res = client.get("/get_cookie")
+        assert res.data.decode() == "true"
+
+def test_get_repeat_post_limit_cookie_set(app):
+    with app.test_client() as client:
+        @app.route("/get_repeat_cookie")
+        def get_cookie_nomal():
+            return get_repeat_post_limit_cookie("123") or "None"
+
+        client.set_cookie("localhost", "repeat_post_limit_123", "alreadyPosted")
+        res = client.get("/get_repeat_cookie")
+        assert res.data.decode() == "alreadyPosted"
+
+def test_get_repeat_post_limit_cookie_none(app):
+    with app.test_client() as client:
+        @app.route("/get_repeat_cookie")
+        def get_cookie_none():
+            return get_repeat_post_limit_cookie("456") or "None"
+
+        res = client.get("/get_repeat_cookie")
+        assert res.data.decode() == "None"
+
+def test_get_repeat_post_limit_cookie_empty_id(app):
+    with app.test_client() as client:
+        @app.route("/get_repeat_cookie")
+        def get_cookie_empty():
+            return get_repeat_post_limit_cookie("") or "None"
+
+        client.set_cookie("localhost", "repeat_post_limit_", "alreadyPosted")
+        res = client.get("/get_repeat_cookie")
+        assert res.data.decode() == "alreadyPosted"
+
+def test_get_repeat_post_limit_cookie_special_id(app):
+    with app.test_client() as client:
+        @app.route("/get_repeat_cookie")
+        def get_cookie_special():
+            return get_repeat_post_limit_cookie("@!#") or "None"
+
+        client.set_cookie("localhost", "repeat_post_limit_@!#", "alreadyPosted")
+        res = client.get("/get_repeat_cookie")
+        assert res.data.decode() == "alreadyPosted"

--- a/ckanext/feedback/tests/services/resource/test_comment.py
+++ b/ckanext/feedback/tests/services/resource/test_comment.py
@@ -26,7 +26,6 @@ from ckanext.feedback.services.resource.comment import (
     get_attached_image_path,
     get_comment_attached_image_files,
     get_comment_reply,
-    get_cookie,
     get_resource,
     get_resource_comment,
     get_resource_comment_categories,
@@ -157,10 +156,6 @@ class TestComments:
         create_reply(comment_id, 'test_reply', user_id)
         session.commit()
         assert get_comment_reply(comment_id)
-
-    def test_get_cookie(self):
-        resource = factories.Resource()
-        assert not get_cookie(resource['id'])
 
 
 class TestResourceComment:


### PR DESCRIPTION
不具合内容：
いいね機能とリピートポストリミット機能を有効にした状態で「いいね」を押すと、
コメントを送信したと判定されてしまい、その後コメントの投稿ができなくなる問題が発生しています。
原因：
「いいね」済みかどうかを判定する cookie と、コメントを投稿済みかどうかを判定する cookie で、
同じキー名が使用されていたことにより、意図しない動作が発生していました。
対応方針：
・cookie のキー名をユニークに設定するよう修正します。
・今後の重複登録を防ぐため、cookie の登録・取得処理は 1 つの共通ファイルに集約し、管理を一元化します。