### PR TITLE
alembic実行時の外部モジュール参照エラーへの対応（Enum定義の2重管理）

### DIFF
--- a/ckanext/feedback/migration/feedback/versions/005_87954668dbb2_.py
+++ b/ckanext/feedback/migration/feedback/versions/005_87954668dbb2_.py
@@ -1,23 +1,29 @@
-"""Create tables: resource_comment_reactions, utilization_comment_reactions
-and enums: resourcecommentresponsestatus, utilizationcommentresponsestatus
+"""Create tables: resource_comment_reactions and enums: resourcecommentresponsestatus
 Revision ID: 87954668dbb2
 Revises: 070e83e52e6b
 Create Date: 2025-05-20 04:37:59.281689
 """
 
+import enum
 import uuid
 from datetime import datetime
 
 import sqlalchemy as sa
 from alembic import op
 
-from ckanext.feedback.models.types import ResourceCommentResponseStatusType
-
 # revision identifiers, used by Alembic.
 revision = '87954668dbb2'
 down_revision = '8ae77eb847cd'
 branch_labels = None
 depends_on = None
+
+
+class ResourceCommentResponseStatus(enum.Enum):
+    STATUS_NONE = 'StatusNone'
+    NOT_STARTED = 'NotStarted'
+    IN_PROGRESS = 'InProgress'
+    COMPLETED = 'Completed'
+    REJECTED = 'Rejected'
 
 
 def upgrade():
@@ -32,7 +38,9 @@ def upgrade():
             ),
             nullable=False,
         ),
-        sa.Column('response_status', ResourceCommentResponseStatusType, nullable=False),
+        sa.Column(
+            'response_status', sa.Enum(ResourceCommentResponseStatus), nullable=False
+        ),
         sa.Column('admin_liked', sa.BOOLEAN, default=False),
         sa.Column('created', sa.TIMESTAMP, default=datetime.now),
         sa.Column('updated', sa.TIMESTAMP),

--- a/ckanext/feedback/models/types.py
+++ b/ckanext/feedback/models/types.py
@@ -1,9 +1,7 @@
 import enum
 
-import sqlalchemy as sa
 
-
-# TODO: Organize and consolidate Enum definitions and sa.Enum wrappers.
+# TODO: Organize and consolidate Enum definitions.
 # 'https://github.com/c-3lab/ckanext-feedback/issues/286'
 class CommentCategory(enum.Enum):
     REQUEST = 'Request'
@@ -17,8 +15,3 @@ class ResourceCommentResponseStatus(enum.Enum):
     IN_PROGRESS = 'InProgress'
     COMPLETED = 'Completed'
     REJECTED = 'Rejected'
-
-
-ResourceCommentResponseStatusType = sa.Enum(
-    ResourceCommentResponseStatus, name='resourcecommentresponsestatus'
-)


### PR DESCRIPTION
**概要**
alembicコマンドによるマイグレーション実行時に、外部モジュール参照エラーが発生していた問題への対応です。  

**原因**
Enum定義は、マイグレーションファイル内とmodelsディレクトリ配下のPythonファイルの双方で定義されていました。  
その後、定義の一元化を目的としてモデル側にのみ集約し、マイグレーションファイルではインポートする形に変更しました。
しかし、alembicコマンド実行時にプロジェクト構成に依存するインポート（外部モジュール）が解決できず、エラーとなっていました。

**対応方針**
- Enum定義をマイグレーションファイル内に再定義（modelsとの2重管理に戻す）
- 外部モジュールのインポートを除去し、alembicの自動マイグレーションでも問題が発生しないように修正

**備考**
- 2重管理によるメンテナンス負荷の増加はあるが、alembicの実行安定性を優先した形
- Enum定義に修正が入った場合、今後はマイグレーションとモデルの両方に修正が必要となる点に注意
- 対策として、Enum定義の変更時に反映漏れを防ぐためのテストコードの実装
