### PR TITLE
ランキングAPI機能改修

### DIFF
--- a/ckanext/feedback/controllers/api/ranking.py
+++ b/ckanext/feedback/controllers/api/ranking.py
@@ -325,25 +325,17 @@ class DatasetRankingService:
         else:
             raise toolkit.ValidationError({"message": "Invalid metric specified."})
 
-        # if not FeedbackConfig().is_feedback_config_file:
-        #     return get_ranking_result
-
-        # if not organization_name:
-        #     return get_ranking_result
-
-        # self.validator.validate_organization_name_in_group(organization_name)
-
         if organization_name:
-            if metric == 'download':
-                self.validator.validate_organization_download_enabled(
-                    organization_name, enable_orgs
-                )
-            elif metric == 'likes':
+            if metric == 'likes':
                 self.validator.validate_organization_likes_enabled(
                     organization_name, enable_orgs
                 )
             elif metric == 'comments':
                 self.validator.validate_organization_comments_enabled(
+                    organization_name, enable_orgs
+                )
+            else:
+                self.validator.validate_organization_download_enabled(
                     organization_name, enable_orgs
                 )
 

--- a/ckanext/feedback/controllers/api/ranking.py
+++ b/ckanext/feedback/controllers/api/ranking.py
@@ -298,6 +298,8 @@ class DatasetRankingService:
         end_year_month,
         organization_name,
     ):
+        if organization_name:
+            self.validator.validate_organization_name_in_group(organization_name)
 
         if metric == 'download':
             self.validator.validate_download_function()
@@ -323,6 +325,28 @@ class DatasetRankingService:
         else:
             raise toolkit.ValidationError({"message": "Invalid metric specified."})
 
+        # if not FeedbackConfig().is_feedback_config_file:
+        #     return get_ranking_result
+
+        # if not organization_name:
+        #     return get_ranking_result
+
+        # self.validator.validate_organization_name_in_group(organization_name)
+
+        if organization_name:
+            if metric == 'download':
+                self.validator.validate_organization_download_enabled(
+                    organization_name, enable_orgs
+                )
+            elif metric == 'likes':
+                self.validator.validate_organization_likes_enabled(
+                    organization_name, enable_orgs
+                )
+            elif metric == 'comments':
+                self.validator.validate_organization_comments_enabled(
+                    organization_name, enable_orgs
+                )
+
         get_ranking_result = dataset_ranking_service.get_generic_ranking(
             top_ranked_limit,
             start_year_month,
@@ -332,28 +356,8 @@ class DatasetRankingService:
             total_model,
             total_column,
             enable_org=None,
+            organization_name=organization_name,
         )
-
-        if not FeedbackConfig().is_feedback_config_file:
-            return get_ranking_result
-
-        if not organization_name:
-            return get_ranking_result
-
-        self.validator.validate_organization_name_in_group(organization_name)
-
-        if metric == 'download':
-            self.validator.validate_organization_download_enabled(
-                organization_name, enable_orgs
-            )
-        elif metric == 'likes':
-            self.validator.validate_organization_likes_enabled(
-                organization_name, enable_orgs
-            )
-        elif metric == 'comments':
-            self.validator.validate_organization_comments_enabled(
-                organization_name, enable_orgs
-            )
         return get_ranking_result
 
     def generate_dataset_ranking_list(self, results, metric_name='download'):

--- a/ckanext/feedback/services/ranking/dataset.py
+++ b/ckanext/feedback/services/ranking/dataset.py
@@ -19,6 +19,7 @@ def get_generic_ranking(
     total_model,
     total_column,
     enable_org=None,
+    organization_name=None,
 ):
     count_by_period = get_count_by_period(
         period_model, period_column, start_year_month, end_year_month
@@ -44,6 +45,10 @@ def get_generic_ranking(
     )
     if enable_org and enable_org != [None]:
         query = query.filter(Group.name.in_(enable_org))
+
+    if organization_name:
+        query = query.filter(Group.name == organization_name)
+
     query = query.order_by(count_by_period.c.count.desc()).limit(top_ranked_limit).all()
     return query
 

--- a/ckanext/feedback/tests/controllers/api/test_ranking.py
+++ b/ckanext/feedback/tests/controllers/api/test_ranking.py
@@ -931,6 +931,11 @@ class TestDatasetRankingController:
         )
         mock_validate_metric.assert_called_once_with('invalid_metric')
 
+    @patch('ckanext.feedback.controllers.api.ranking.FeedbackConfig')
+    @patch(
+        'ckanext.feedback.controllers.api.ranking.'
+        'dataset_ranking_service.get_generic_ranking'
+    )
     @pytest.mark.parametrize(
         "metric,"
         "organization_name,"
@@ -1010,7 +1015,6 @@ class TestDatasetRankingController:
             ),
         ],
     )
-    @patch('ckanext.feedback.controllers.api.ranking.FeedbackConfig')
     def test_get_dataset_ranking_parametrized(
         self,
         mock_get_generic_ranking,

--- a/ckanext/feedback/tests/services/ranking/test_dataset.py
+++ b/ckanext/feedback/tests/services/ranking/test_dataset.py
@@ -1,127 +1,420 @@
 import logging
 
 import pytest
-from ckan import model
-from ckan.tests import factories
 
 import ckanext.feedback.services.ranking.dataset as dataset_ranking_service
-from ckanext.feedback.command.feedback import (
-    create_download_tables,
-    create_resource_tables,
-    create_utilization_tables,
-)
 from ckanext.feedback.models.download import DownloadMonthly, DownloadSummary
 from ckanext.feedback.models.session import session
 
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.usefixtures('clean_db', 'with_plugins', 'with_request_context')
+@pytest.mark.db_test
+@pytest.mark.usefixtures('with_plugins', 'with_request_context')
 class TestRankingDataset:
-    @classmethod
-    def setup_class(cls):
-        model.repo.init_db()
-        engine = model.meta.engine
-        create_utilization_tables(engine)
-        create_resource_tables(engine)
-        create_download_tables(engine)
+    pass
 
-    def test_get_download_ranking(self):
-        organization = factories.Organization()
-        package = factories.Dataset(owner_org=organization['id'])
-        resource = factories.Resource(package_id=package['id'])
-
-        top_ranked_limit = '1'
-        start_year_month = '2023-01'
-        end_year_month = '2023-12'
-        enable_org = [organization['name']]
-
+    def test_get_download_ranking(self, organization, dataset, resource):
         assert (
-            dataset_ranking_service.get_download_ranking(
-                top_ranked_limit, start_year_month, end_year_month, enable_org
+            dataset_ranking_service.get_generic_ranking(
+                1,
+                '2023-01',
+                '2023-12',
+                DownloadMonthly,
+                'download_count',
+                DownloadSummary,
+                'download',
+                [organization['name']],
             )
             == []
         )
 
-        download_summary = DownloadSummary(
-            id=str('test_id'),
-            resource_id=resource['id'],
-            download=1,
-            created='2023-03-31 01:23:45.123456',
-            updated='2023-03-31 01:23:45.123456',
+        session.add(
+            DownloadSummary(
+                id='sum1',
+                resource_id=resource['id'],
+                download=1,
+                created='2023-03-31 01:23:45',
+                updated='2023-03-31 01:23:45',
+            )
         )
-        session.add(download_summary)
-
-        download_monthly = DownloadMonthly(
-            id=str('test_id'),
-            resource_id=resource['id'],
-            download_count=1,
-            created='2023-03-31 01:23:45.123456',
-            updated='2023-03-31 01:23:45.123456',
+        session.add(
+            DownloadMonthly(
+                id='mon1',
+                resource_id=resource['id'],
+                download_count=1,
+                created='2023-03-31 01:23:45',
+                updated='2023-03-31 01:23:45',
+            )
         )
-        session.add(download_monthly)
         session.commit()
 
-        assert dataset_ranking_service.get_download_ranking(
-            top_ranked_limit, start_year_month, end_year_month, enable_org
-        ) == [
-            (
-                organization['name'],
-                organization['title'],
-                package['name'],
-                package['title'],
-                package['notes'],
-                1,
-                1,
-            )
-        ]
+        result = dataset_ranking_service.get_generic_ranking(
+            1,
+            '2023-01',
+            '2023-12',
+            DownloadMonthly,
+            'download_count',
+            DownloadSummary,
+            'download',
+            [organization['name']],
+        )
+        assert len(result) == 1
 
-    def test_get_download_ranking_enable_org_none(self):
-        organization = factories.Organization()
-        package = factories.Dataset(owner_org=organization['id'])
-        resource = factories.Resource(package_id=package['id'])
-
-        top_ranked_limit = '1'
-        start_year_month = '2023-01'
-        end_year_month = '2023-12'
-        enable_org = []
-
+    def test_get_download_ranking_enable_org_none(
+        self, organization, dataset, resource
+    ):
         assert (
-            dataset_ranking_service.get_download_ranking(
-                top_ranked_limit, start_year_month, end_year_month, enable_org
+            dataset_ranking_service.get_generic_ranking(
+                1,
+                '2023-01',
+                '2023-12',
+                DownloadMonthly,
+                'download_count',
+                DownloadSummary,
+                'download',
+                [],
             )
             == []
         )
 
-        download_summary = DownloadSummary(
-            id=str('test_id'),
-            resource_id=resource['id'],
-            download=1,
-            created='2023-03-31 01:23:45.123456',
-            updated='2023-03-31 01:23:45.123456',
+        session.add(
+            DownloadSummary(
+                id='sum1',
+                resource_id=resource['id'],
+                download=1,
+                created='2023-03-31 01:23:45',
+                updated='2023-03-31 01:23:45',
+            )
         )
-        session.add(download_summary)
-
-        download_monthly = DownloadMonthly(
-            id=str('test_id'),
-            resource_id=resource['id'],
-            download_count=1,
-            created='2023-03-31 01:23:45.123456',
-            updated='2023-03-31 01:23:45.123456',
+        session.add(
+            DownloadMonthly(
+                id='mon1',
+                resource_id=resource['id'],
+                download_count=1,
+                created='2023-03-31 01:23:45',
+                updated='2023-03-31 01:23:45',
+            )
         )
-        session.add(download_monthly)
         session.commit()
 
-        assert dataset_ranking_service.get_download_ranking(
-            top_ranked_limit, start_year_month, end_year_month, enable_org
-        ) == [
-            (
-                organization['name'],
-                organization['title'],
-                package['name'],
-                package['title'],
-                package['notes'],
-                1,
-                1,
+        result = dataset_ranking_service.get_generic_ranking(
+            1,
+            '2023-01',
+            '2023-12',
+            DownloadMonthly,
+            'download_count',
+            DownloadSummary,
+            'download',
+            [],
+        )
+        assert len(result) == 1
+
+    def test_get_download_ranking_sorted_and_limited(
+        self, organization_factory, package_factory, resource_factory
+    ):
+        org_a = organization_factory()
+        org_b = organization_factory()
+        pkg_a = package_factory(owner_org=org_a['id'])
+        pkg_b = package_factory(owner_org=org_b['id'])
+        res_a = resource_factory(package_id=pkg_a['id'])
+        res_b = resource_factory(package_id=pkg_b['id'])
+
+        session.add(
+            DownloadSummary(
+                id='sum_a',
+                resource_id=res_a['id'],
+                download=5,
+                created='2023-03-31 01:23:45',
+                updated='2023-03-31 01:23:45',
             )
-        ]
+        )
+        session.add(
+            DownloadMonthly(
+                id='mon_a',
+                resource_id=res_a['id'],
+                download_count=5,
+                created='2023-03-31 01:23:45',
+                updated='2023-03-31 01:23:45',
+            )
+        )
+        session.add(
+            DownloadSummary(
+                id='sum_b',
+                resource_id=res_b['id'],
+                download=2,
+                created='2023-03-31 01:23:45',
+                updated='2023-03-31 01:23:45',
+            )
+        )
+        session.add(
+            DownloadMonthly(
+                id='mon_b',
+                resource_id=res_b['id'],
+                download_count=2,
+                created='2023-03-31 01:23:45',
+                updated='2023-03-31 01:23:45',
+            )
+        )
+        session.commit()
+
+        result = dataset_ranking_service.get_generic_ranking(
+            1,
+            '2023-01',
+            '2023-12',
+            DownloadMonthly,
+            'download_count',
+            DownloadSummary,
+            'download',
+            [org_a['name'], org_b['name']],
+        )
+        assert len(result) == 1
+        assert result[0][0] == org_a['name']
+
+    def test_get_download_ranking_filter_by_organization_name(
+        self, organization_factory, package_factory, resource_factory
+    ):
+        org_a = organization_factory()
+        org_b = organization_factory()
+        pkg_a = package_factory(owner_org=org_a['id'])
+        pkg_b = package_factory(owner_org=org_b['id'])
+        res_a = resource_factory(package_id=pkg_a['id'])
+        res_b = resource_factory(package_id=pkg_b['id'])
+
+        session.add(
+            DownloadSummary(
+                id='sum_a2',
+                resource_id=res_a['id'],
+                download=1,
+                created='2023-03-31 00:00:00',
+                updated='2023-03-31 00:00:00',
+            )
+        )
+        session.add(
+            DownloadMonthly(
+                id='mon_a2',
+                resource_id=res_a['id'],
+                download_count=1,
+                created='2023-03-01 00:00:00',
+                updated='2023-03-01 00:00:00',
+            )
+        )
+        session.add(
+            DownloadSummary(
+                id='sum_b2',
+                resource_id=res_b['id'],
+                download=1,
+                created='2023-03-31 00:00:00',
+                updated='2023-03-31 00:00:00',
+            )
+        )
+        session.add(
+            DownloadMonthly(
+                id='mon_b2',
+                resource_id=res_b['id'],
+                download_count=1,
+                created='2023-03-01 00:00:00',
+                updated='2023-03-01 00:00:00',
+            )
+        )
+        session.commit()
+
+        result = dataset_ranking_service.get_generic_ranking(
+            10,
+            '2023-01',
+            '2023-12',
+            DownloadMonthly,
+            'download_count',
+            DownloadSummary,
+            'download',
+            [org_a['name'], org_b['name']],
+            organization_name=org_a['name'],
+        )
+        assert len(result) == 1
+        assert result[0][0] == org_a['name']
+
+    def test_get_download_ranking_enable_org_none_list(
+        self, organization, package, resource
+    ):
+        session.add(
+            DownloadSummary(
+                id=str('sum_none'),
+                resource_id=resource['id'],
+                download=1,
+                created='2023-03-31 01:23:45.123456',
+                updated='2023-03-31 01:23:45.123456',
+            )
+        )
+        session.add(
+            DownloadMonthly(
+                id=str('mon_none'),
+                resource_id=resource['id'],
+                download_count=1,
+                created='2023-03-31 01:23:45.123456',
+                updated='2023-03-31 01:23:45.123456',
+            )
+        )
+        session.commit()
+
+        result = dataset_ranking_service.get_generic_ranking(
+            10,
+            '2023-01',
+            '2023-12',
+            DownloadMonthly,
+            'download_count',
+            DownloadSummary,
+            'download',
+            [None],
+        )
+        assert len(result) == 1
+        assert result[0][0] == organization['name']
+
+    def test_get_download_ranking_date_range_inclusive(
+        self, organization, package, resource
+    ):
+        session.add(
+            DownloadSummary(
+                id=str('sum_edge1'),
+                resource_id=resource['id'],
+                download=1,
+                created='2023-03-31 23:59:59',
+                updated='2023-03-31 23:59:59',
+            )
+        )
+        session.add(
+            DownloadMonthly(
+                id=str('mon_edge1'),
+                resource_id=resource['id'],
+                download_count=1,
+                created='2023-03-01 00:00:00',
+                updated='2023-03-01 00:00:00',
+            )
+        )
+
+        session.add(
+            DownloadSummary(
+                id=str('sum_out1'),
+                resource_id=resource['id'],
+                download=99,
+                created='2023-04-01 00:00:00',
+                updated='2023-04-01 00:00:00',
+            )
+        )
+        session.add(
+            DownloadMonthly(
+                id=str('mon_out1'),
+                resource_id=resource['id'],
+                download_count=99,
+                created='2023-02-28 23:59:59',
+                updated='2023-02-28 23:59:59',
+            )
+        )
+        session.commit()
+
+        result = dataset_ranking_service.get_generic_ranking(
+            10,
+            '2023-03',
+            '2023-03',
+            DownloadMonthly,
+            'download_count',
+            DownloadSummary,
+            'download',
+            [organization['name']],
+        )
+
+        assert len(result) == 1
+        assert result[0][5] == 1
+        assert result[0][6] == 100
+
+    def test_get_download_ranking_excludes_inactive_package_or_group(
+        self, organization, package_factory, resource_factory
+    ):
+        pkg = package_factory(owner_org=organization['id'], state='deleted')
+        res = resource_factory(package_id=pkg['id'])
+
+        session.add(
+            DownloadSummary(
+                id='sum_inactive_pkg',
+                resource_id=res['id'],
+                download=1,
+                created='2023-03-31 00:00:00',
+                updated='2023-03-31 00:00:00',
+            )
+        )
+        session.add(
+            DownloadMonthly(
+                id='mon_inactive_pkg',
+                resource_id=res['id'],
+                download_count=1,
+                created='2023-03-01 00:00:00',
+                updated='2023-03-01 00:00:00',
+            )
+        )
+        session.commit()
+
+        result = dataset_ranking_service.get_generic_ranking(
+            10,
+            '2023-01',
+            '2023-12',
+            DownloadMonthly,
+            'download_count',
+            DownloadSummary,
+            'download',
+            [organization['name']],
+        )
+        assert result == []
+
+    def test_get_last_day_of_month(self):
+        assert dataset_ranking_service.get_last_day_of_month(2023, 1) == 31
+        assert dataset_ranking_service.get_last_day_of_month(2023, 2) == 28
+        assert dataset_ranking_service.get_last_day_of_month(2024, 2) == 29
+
+    def test_no_result_if_only_period_or_only_total_exists(
+        self, organization, package, resource
+    ):
+        session.add(
+            DownloadMonthly(
+                id=str('mon_only'),
+                resource_id=resource['id'],
+                download_count=1,
+                created='2023-03-31 00:00:00',
+                updated='2023-03-31 00:00:00',
+            )
+        )
+        session.commit()
+
+        result1 = dataset_ranking_service.get_generic_ranking(
+            10,
+            '2023-01',
+            '2023-12',
+            DownloadMonthly,
+            'download_count',
+            DownloadSummary,
+            'download',
+            [organization['name']],
+        )
+        assert result1 == []
+
+        session.query(DownloadMonthly).delete()
+        session.add(
+            DownloadSummary(
+                id=str('sum_only'),
+                resource_id=resource['id'],
+                download=1,
+                created='2023-03-31 00:00:00',
+                updated='2023-03-31 00:00:00',
+            )
+        )
+        session.commit()
+
+        result2 = dataset_ranking_service.get_generic_ranking(
+            10,
+            '2023-01',
+            '2023-12',
+            DownloadMonthly,
+            'download_count',
+            DownloadSummary,
+            'download',
+            [organization['name']],
+        )
+        assert result2 == []

--- a/docs/ja/datasets_ranking_api.md
+++ b/docs/ja/datasets_ranking_api.md
@@ -17,7 +17,7 @@ GET /api/3/action/datasets_ranking
 | period_months_ago    | 相対期間（過去Xヶ月）        | string   | 任意 | なし                    | 例: `3`を指定すると、直近3ヶ月間の集計を取得します。     |
 | start_year_month     | 固定期間の開始年月          | string| 任意 | 2023-04                    | 例: `2024-01` で2024年1月が開始。  
 | end_year_month       | 固定期間の終了年月          | string| 任意 | 先月                    | 例: `2024-03` で2024年3月が終了。開始・終了ともに指定した場合、その期間で集計します。 |
-| aggregation_metric   | 集計指標                     | string| 任意 | "download"              |  |
+| aggregation_metric   | 集計指標                     | string| 任意 | "download"              | `"likes"`いいね数,`"comment"`コメント数でも集計指標を指定可能。 |
 | organization_name    | 組織名による絞り込み       | string| 任意 | なし  |   |
 
 ## 出力（レスポンス）の説明
@@ -36,6 +36,10 @@ GET /api/3/action/datasets_ranking
 | dataset_link | データセットのURL | string |  |
 | download_count_by_period | 集計期間内のダウンロード数 | int | aggregation_metric として download を指定した場合に存在する |
 | total_download_count | 全期間のダウンロード数 | int | aggregation_metric として download を指定した場合に存在する |
+| likes_count_by_period | 集計期間内のいいね数 | int | aggregation_metric として likes を指定した場合に存在する |
+| total_likes_count | 全期間のいいね数 | int | aggregation_metric として likes を指定した場合に存在する |
+| comments_count_by_period | 集計期間内のコメント数 | int | aggregation_metric として comments を指定した場合に存在する |
+| total_comments_count | 全期間のコメント数 | int | aggregation_metric として comments を指定した場合に存在する |
 
 ## レスポンス例
 


### PR DESCRIPTION
## 概要
ランキングAPIの集計対象をいいね数とコメント数でも集計可能にしました。
 
### 主な修正点

 
 