### PR TITLE
パフォーマンス改善対応のテストコード追加

### DIFF
--- a/ckanext/feedback/tests/services/download/test_summary.py
+++ b/ckanext/feedback/tests/services/download/test_summary.py
@@ -6,6 +6,7 @@ from ckanext.feedback.models.download import DownloadSummary
 from ckanext.feedback.models.session import session
 from ckanext.feedback.services.download.summary import (
     get_package_downloads,
+    get_package_downloads_bulk,
     get_resource_downloads,
     increment_resource_downloads,
 )
@@ -25,6 +26,14 @@ class TestDownloadServices:
         assert (
             get_package_downloads(resource['package_id']) == download_summary.download
         )
+
+    def test_get_package_downloads_bulk_with_data(self, resource, download_summary):
+        result = get_package_downloads_bulk([resource['package_id']])
+        assert result == {resource['package_id']: download_summary.download}
+
+    def test_get_package_downloads_bulk_with_no_data(self, resource):
+        result = get_package_downloads_bulk(['non-existent-package-id'])
+        assert result == {}
 
     def test_get_resource_download(self, resource, download_summary):
         assert get_resource_downloads(resource['id']) == download_summary.download

--- a/ckanext/feedback/tests/services/package/test_summary.py
+++ b/ckanext/feedback/tests/services/package/test_summary.py
@@ -1,0 +1,179 @@
+from unittest.mock import MagicMock, patch
+
+from ckanext.feedback.services.package.summary import (
+    get_package_feedback_stats_bulk,
+    get_package_id_from_packages,
+)
+
+
+class TestSummary:
+    def test_get_package_id_from_packages_with_none(self):
+        assert get_package_id_from_packages(None) is None
+
+    def test_get_package_id_from_packages_with_empty_dict(self):
+        assert get_package_id_from_packages({}) is None
+
+    def test_get_package_id_from_packages_with_dict_having_id(self):
+        assert get_package_id_from_packages({'id': 'abc-123'}) == 'abc-123'
+
+    def test_get_package_id_from_packages_with_dict_without_id(self):
+        assert get_package_id_from_packages({'name': 'test-dataset'}) is None
+
+    def test_get_package_id_from_packages_with_object_having_id(self):
+        obj = MagicMock()
+        obj.id = 'abc-123'
+        assert get_package_id_from_packages(obj) == 'abc-123'
+
+    def test_get_package_id_from_packages_with_object_without_id(self):
+        obj = MagicMock(spec=[])
+        assert get_package_id_from_packages(obj) is None
+
+    def test_get_package_id_from_packages_with_id_as_whitespace(self):
+        assert get_package_id_from_packages({'id': '   '}) is None
+
+    def test_get_package_id_from_packages_with_id_as_string_none(self):
+        assert get_package_id_from_packages({'id': 'None'}) is None
+
+    def test_get_package_id_from_packages_with_id_none_value(self):
+        assert get_package_id_from_packages({'id': None}) is None
+
+    def test_get_package_feedback_stats_bulk_with_empty_list(self):
+        assert get_package_feedback_stats_bulk([]) == {}
+
+    @patch('ckanext.feedback.services.package.summary.resource_likes_service')
+    @patch('ckanext.feedback.services.package.summary.download_summary_service')
+    @patch('ckanext.feedback.services.package.summary.utilization_summary_service')
+    @patch('ckanext.feedback.services.package.summary.resource_summary_service')
+    def test_get_package_feedback_stats_bulk_with_all_invalid_packages(
+        self,
+        mock_resource_summary_service,
+        mock_utilization_summary_service,
+        mock_download_summary_service,
+        mock_resource_likes_service,
+    ):
+        result = get_package_feedback_stats_bulk([None, {}])
+        assert result == {}
+        mock_resource_likes_service.get_package_like_count_bulk.assert_not_called()
+
+        result = get_package_feedback_stats_bulk([{'name': 'test-dataset'}])
+        assert result == {}
+        mock_resource_likes_service.get_package_like_count_bulk.assert_not_called()
+
+    @patch('ckanext.feedback.services.package.summary.resource_likes_service')
+    @patch('ckanext.feedback.services.package.summary.download_summary_service')
+    @patch('ckanext.feedback.services.package.summary.utilization_summary_service')
+    @patch('ckanext.feedback.services.package.summary.resource_summary_service')
+    def test_get_package_feedback_stats_bulk_with_rating_zero(
+        self,
+        mock_resource_summary_service,
+        mock_utilization_summary_service,
+        mock_download_summary_service,
+        mock_resource_likes_service,
+    ):
+        pid = 'abc-123'
+        mock_resource_likes_service.get_package_like_count_bulk.return_value = {pid: 5}
+        mock_download_summary_service.get_package_downloads_bulk.return_value = {
+            pid: 10
+        }
+        mock_utilization_summary_service.get_package_utilizations_bulk.return_value = {
+            pid: 3
+        }
+        issue_resolutions_bulk = (
+            mock_utilization_summary_service.get_package_issue_resolutions_bulk
+        )
+        issue_resolutions_bulk.return_value = {pid: 1}
+        mock_resource_summary_service.get_package_comments_bulk.return_value = {pid: 7}
+        mock_resource_summary_service.get_package_rating_bulk.return_value = {pid: 0}
+
+        result = get_package_feedback_stats_bulk([{'id': pid}])
+        assert result == {
+            pid: {
+                'like_count': 5,
+                'downloads': 10,
+                'utilizations': 3,
+                'comments': 7,
+                'rating': 0,
+                'issue_resolutions': 1,
+            }
+        }
+
+    @patch('ckanext.feedback.services.package.summary.resource_likes_service')
+    @patch('ckanext.feedback.services.package.summary.download_summary_service')
+    @patch('ckanext.feedback.services.package.summary.utilization_summary_service')
+    @patch('ckanext.feedback.services.package.summary.resource_summary_service')
+    def test_get_package_feedback_stats_bulk_with_rating_nonzero(
+        self,
+        mock_resource_summary_service,
+        mock_utilization_summary_service,
+        mock_download_summary_service,
+        mock_resource_likes_service,
+    ):
+        pid = 'abc-123'
+        mock_resource_likes_service.get_package_like_count_bulk.return_value = {pid: 2}
+        mock_download_summary_service.get_package_downloads_bulk.return_value = {pid: 4}
+        mock_utilization_summary_service.get_package_utilizations_bulk.return_value = {
+            pid: 1
+        }
+        issue_resolutions_bulk = (
+            mock_utilization_summary_service.get_package_issue_resolutions_bulk
+        )
+        issue_resolutions_bulk.return_value = {pid: 0}
+        mock_resource_summary_service.get_package_comments_bulk.return_value = {pid: 6}
+        mock_resource_summary_service.get_package_rating_bulk.return_value = {
+            pid: 4.666
+        }
+
+        result = get_package_feedback_stats_bulk([{'id': pid}])
+        assert result == {
+            pid: {
+                'like_count': 2,
+                'downloads': 4,
+                'utilizations': 1,
+                'comments': 6,
+                'rating': 4.7,
+                'issue_resolutions': 0,
+            }
+        }
+
+    @patch('ckanext.feedback.services.package.summary.resource_likes_service')
+    @patch('ckanext.feedback.services.package.summary.download_summary_service')
+    @patch('ckanext.feedback.services.package.summary.utilization_summary_service')
+    @patch('ckanext.feedback.services.package.summary.resource_summary_service')
+    def test_get_package_feedback_stats_bulk_with_mixed_packages(
+        self,
+        mock_resource_summary_service,
+        mock_utilization_summary_service,
+        mock_download_summary_service,
+        mock_resource_likes_service,
+    ):
+        pid1 = 'abc-123'
+        pid2 = 'def-456'
+        mock_resource_likes_service.get_package_like_count_bulk.return_value = {
+            pid1: 1,
+            pid2: 2,
+        }
+        mock_download_summary_service.get_package_downloads_bulk.return_value = {
+            pid1: 3,
+            pid2: 4,
+        }
+        mock_utilization_summary_service.get_package_utilizations_bulk.return_value = {
+            pid1: 0,
+            pid2: 0,
+        }
+        issue_resolutions_bulk = (
+            mock_utilization_summary_service.get_package_issue_resolutions_bulk
+        )
+        issue_resolutions_bulk.return_value = {pid1: 0, pid2: 0}
+        mock_resource_summary_service.get_package_comments_bulk.return_value = {
+            pid1: 0,
+            pid2: 0,
+        }
+        mock_resource_summary_service.get_package_rating_bulk.return_value = {
+            pid1: 0,
+            pid2: 0,
+        }
+
+        result = get_package_feedback_stats_bulk([{'id': pid1}, None, {'id': pid2}])
+        assert set(result.keys()) == {pid1, pid2}
+        assert result[pid1]['like_count'] == 1
+        assert result[pid2]['like_count'] == 2

--- a/ckanext/feedback/tests/services/resource/test_likes.py
+++ b/ckanext/feedback/tests/services/resource/test_likes.py
@@ -8,6 +8,7 @@ from ckanext.feedback.services.resource.likes import (
     decrement_resource_like_count,
     decrement_resource_like_count_monthly,
     get_package_like_count,
+    get_package_like_count_bulk,
     get_resource_like_count,
     get_resource_like_count_monthly,
     increment_resource_like_count,
@@ -128,6 +129,14 @@ class TestLikes:
         assert (
             get_package_like_count(resource['package_id']) == resource_like.like_count
         )
+
+    def test_get_package_like_count_bulk_with_data(self, resource, resource_like):
+        result = get_package_like_count_bulk([resource['package_id']])
+        assert result == {resource['package_id']: resource_like.like_count}
+
+    def test_get_package_like_count_bulk_with_no_data(self, resource):
+        result = get_package_like_count_bulk(['non-existent-package-id'])
+        assert result == {}
 
     def test_get_resource_like_count_monthly(self, resource_like_monthly):
         assert (

--- a/ckanext/feedback/tests/services/resource/test_summary.py
+++ b/ckanext/feedback/tests/services/resource/test_summary.py
@@ -14,7 +14,9 @@ from ckanext.feedback.services.resource.comment import (
 from ckanext.feedback.services.resource.summary import (
     create_resource_summary,
     get_package_comments,
+    get_package_comments_bulk,
     get_package_rating,
+    get_package_rating_bulk,
     get_resource_comments,
     get_resource_rating,
     refresh_resource_summary,
@@ -26,6 +28,14 @@ class TestSummary:
     def test_get_package_comments(self, resource, resource_comment):
         result = get_package_comments(resource['package_id'])
         assert result == 1
+
+    def test_get_package_comments_bulk_with_data(self, resource, resource_comment):
+        result = get_package_comments_bulk([resource['package_id']])
+        assert result == {resource['package_id']: 1}
+
+    def test_get_package_comments_bulk_with_no_data(self):
+        result = get_package_comments_bulk(['non-existent-package-id'])
+        assert result == {}
 
     def test_get_resource_comments(self, resource, resource_comment):
         result = get_resource_comments(resource['id'])
@@ -39,9 +49,22 @@ class TestSummary:
         result = get_package_rating(resource['package_id'])
         assert result == 0
 
+    def test_get_package_rating_bulk_with_data(self, resource, resource_comment):
+        result = get_package_rating_bulk([resource['package_id']])
+        assert resource['package_id'] in result
+        assert result[resource['package_id']] == resource_comment.rating
+
+    def test_get_package_rating_bulk_with_no_data(self):
+        result = get_package_rating_bulk(['non-existent-package-id'])
+        assert result == {}
+
     def test_get_resource_rating(self, resource, resource_comment):
         result = get_resource_rating(resource['id'])
         assert result == resource_comment.rating
+
+    def test_get_resource_rating_with_no_summary(self, resource):
+        result = get_resource_rating(resource['id'])
+        assert result == 0
 
     def test_create_resource_summary(self, resource):
         create_resource_summary(resource['id'])

--- a/ckanext/feedback/tests/services/utilization/test_summary.py
+++ b/ckanext/feedback/tests/services/utilization/test_summary.py
@@ -9,7 +9,9 @@ from ckanext.feedback.models.utilization import Utilization, UtilizationSummary
 from ckanext.feedback.services.utilization.summary import (
     create_utilization_summary,
     get_package_issue_resolutions,
+    get_package_issue_resolutions_bulk,
     get_package_utilizations,
+    get_package_utilizations_bulk,
     get_resource_issue_resolutions,
     get_resource_utilizations,
     increment_issue_resolution_summary,
@@ -97,6 +99,19 @@ class TestUtilizationDetailsService:
         assert utilization_summary.created == datetime(2024, 1, 1, 15, 0, 0)
         assert utilization_summary.updated == datetime(2024, 1, 1, 15, 0, 0)
 
+    def test_get_package_utilizations_bulk_with_data(self, dataset, resource):
+        id = str(uuid.uuid4())
+        register_utilization(id, resource['id'], 'title', 'description', True)
+        refresh_utilization_summary(resource['id'])
+        session.commit()
+
+        result = get_package_utilizations_bulk([dataset['id']])
+        assert result == {dataset['id']: 1}
+
+    def test_get_package_utilizations_bulk_with_no_data(self):
+        result = get_package_utilizations_bulk(['non-existent-package-id'])
+        assert result == {}
+
     def test_get_package_issue_resolutions(self, dataset, resource):
         utilization_id = str(uuid.uuid4())
         title = 'test title'
@@ -124,6 +139,21 @@ class TestUtilizationDetailsService:
         resister_issue_resolution_summary(str(uuid.uuid4()), utilization_id, time, time)
 
         assert get_resource_issue_resolutions(resource['id']) == 1
+
+    def test_get_package_issue_resolutions_bulk_with_data(self, dataset, resource):
+        utilization_id = str(uuid.uuid4())
+        time = datetime.now()
+        register_utilization(
+            utilization_id, resource['id'], 'title', 'description', True
+        )
+        resister_issue_resolution_summary(str(uuid.uuid4()), utilization_id, time, time)
+
+        result = get_package_issue_resolutions_bulk([dataset['id']])
+        assert result == {dataset['id']: 1}
+
+    def test_get_package_issue_resolutions_bulk_with_no_data(self):
+        result = get_package_issue_resolutions_bulk(['non-existent-package-id'])
+        assert result == {}
 
     @pytest.mark.freeze_time(datetime(2024, 1, 1, 15, 0, 0))
     def test_increment_issue_resolution_summary(self, utilization):

--- a/ckanext/feedback/tests/test_plugin.py
+++ b/ckanext/feedback/tests/test_plugin.py
@@ -201,10 +201,32 @@ class TestPlugin:
             {'key': 'Number of Likes', 'value': 9999},
         ]
 
+        dataset['extras'] = [{'key': 'existing_key', 'value': 'existing_value'}]
+        instance.before_dataset_view(dataset)
+        assert dataset['extras'] == [
+            {'key': 'existing_key', 'value': 'existing_value'},
+            {'key': 'Downloads', 'value': 9999},
+            {'key': 'Utilizations', 'value': 9999},
+            {'key': 'Issue Resolutions', 'value': 9999},
+            {'key': 'Comments', 'value': 9999},
+            {'key': 'Rating', 'value': 23.3},
+            {'key': 'Number of Likes', 'value': 9999},
+        ]
+
+    @patch('ckanext.feedback.plugin._', side_effect=lambda msg: msg)
+    @patch(
+        'ckanext.feedback.plugin.package_summary_service.'
+        'get_package_feedback_stats_bulk'
+    )
+    @patch('flask.request', new_callable=MagicMock)
     def test_before_dataset_view_with_False(
         self,
+        mock_request,
+        mock_get_package_feedback_stats_bulk,
+        _mock_plugin_ugettext,
     ):
         instance = FeedbackPlugin()
+        mock_request.endpoint = 'dataset.read'
 
         config[f"{FeedbackConfig().resource_comment.get_ckan_conf_str()}.enable"] = (
             False
@@ -212,14 +234,19 @@ class TestPlugin:
         config[f"{FeedbackConfig().utilization.get_ckan_conf_str()}.enable"] = False
         config[f"{FeedbackConfig().download.get_ckan_conf_str()}.enable"] = False
         config[f"{FeedbackConfig().like.get_ckan_conf_str()}.enable"] = False
+
         dataset = factories.Dataset()
-        dataset['extras'] = [
-            'test',
-        ]
-        before_dataset = dataset
+        mock_get_package_feedback_stats_bulk.return_value = {dataset['id']: {}}
+        dataset['extras'] = [{'key': 'already', 'value': 'exists'}]
 
         instance.before_dataset_view(dataset)
-        assert before_dataset == dataset
+        assert dataset['extras'] == [{'key': 'already', 'value': 'exists'}]
+
+        mock_request.endpoint = 'dataset.search'
+        dataset['extras'] = [{'key': 'already', 'value': 'exists'}]
+        result = instance.before_dataset_view(dataset)
+        assert result == dataset
+        assert dataset['extras'] == [{'key': 'already', 'value': 'exists'}]
 
     @patch('ckanext.feedback.plugin.download_summary_service')
     @patch('ckanext.feedback.plugin.utilization_summary_service')


### PR DESCRIPTION
## 概要

テストカバレッジの不足を補うため、テストコードを追加・修正しました。

## 主な修正点

* `before_dataset_view` のブランチカバレッジを改善
  * `extras` に既存データがある場合の初期化スキップルートを追加
  * 全機能無効時に `skip_endpoints` による早期 return ルートを追加
* 各サービス層に追加された `_bulk` 系関数のテストを追加
  * `get_package_downloads_bulk`
  * `get_package_like_count_bulk`
  * `get_package_comments_bulk`
  * `get_package_rating_bulk`
  * `get_package_utilizations_bulk`
  * `get_package_issue_resolutions_bulk`
* `get_package_id_from_packages` の各入力パターンに対するテストを新規追加
* `get_package_feedback_stats_bulk` の各ブランチに対するテストを新規追加
* `get_resource_rating` の `rating is None` ルートを追加

## 主な追加・修正ファイル

- `ckanext/feedback/tests/test_plugin.py`
- `ckanext/feedback/tests/services/package/test_summary.py`（新規）
- `ckanext/feedback/tests/services/download/test_summary.py`
- `ckanext/feedback/tests/services/resource/test_likes.py`
- `ckanext/feedback/tests/services/resource/test_summary.py`
- `ckanext/feedback/tests/services/utilization/test_summary.py`